### PR TITLE
Change DefaultSkin[Skin] to DefaultSkin { type Default }

### DIFF
--- a/core/src/main/scala/eu/joaocosta/interim/skins/ButtonSkin.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/skins/ButtonSkin.scala
@@ -10,7 +10,7 @@ trait ButtonSkin:
       uiState: UiState
   ): Unit
 
-object ButtonSkin extends DefaultSkin[ButtonSkin]:
+object ButtonSkin extends DefaultSkin:
   final case class Default(
       shadowDelta: Int,
       clickDelta: Int,
@@ -47,7 +47,7 @@ object ButtonSkin extends DefaultSkin[ButtonSkin]:
         case _ =>
           text(buttonArea, textColor, label, fontSize, HorizontalAlignment.Center, VerticalAlignment.Center)
 
-  val lightDefault = Default(
+  val lightDefault: Default = Default(
     shadowDelta = 4,
     clickDelta = 2,
     fontSize = 8,
@@ -58,7 +58,7 @@ object ButtonSkin extends DefaultSkin[ButtonSkin]:
     activeColor = ColorScheme.lightPrimaryHighlight
   )
 
-  val darkDefault = Default(
+  val darkDefault: Default = Default(
     shadowDelta = 0,
     clickDelta = 2,
     fontSize = 8,

--- a/core/src/main/scala/eu/joaocosta/interim/skins/CheckboxSkin.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/skins/CheckboxSkin.scala
@@ -7,7 +7,7 @@ trait CheckboxSkin:
   def checkboxArea(area: Rect): Rect
   def renderCheckbox(area: Rect, value: Boolean, itemStatus: UiState.ItemStatus)(implicit uiState: UiState): Unit
 
-object CheckboxSkin extends DefaultSkin[CheckboxSkin]:
+object CheckboxSkin extends DefaultSkin:
   final case class Default(
       padding: Int,
       inactiveColor: Color,
@@ -33,7 +33,7 @@ object CheckboxSkin extends DefaultSkin[CheckboxSkin]:
           checkColor
         )
 
-  val lightDefault = Default(
+  val lightDefault: Default = Default(
     padding = 4,
     inactiveColor = ColorScheme.lightGray,
     hotColor = ColorScheme.lightPrimary,
@@ -41,7 +41,7 @@ object CheckboxSkin extends DefaultSkin[CheckboxSkin]:
     checkColor = ColorScheme.black
   )
 
-  val darkDefault = Default(
+  val darkDefault: Default = Default(
     padding = 4,
     inactiveColor = ColorScheme.darkGray,
     hotColor = ColorScheme.darkPrimary,

--- a/core/src/main/scala/eu/joaocosta/interim/skins/DefaultSkin.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/skins/DefaultSkin.scala
@@ -2,10 +2,12 @@ package eu.joaocosta.interim.skins
 
 /** Default Skin companion object. Includes both a light and dark mode.
   */
-trait DefaultSkin[Skin]:
-  def default(): Skin =
+trait DefaultSkin:
+  type Default
+
+  def default(): Default =
     if (ColorScheme.lightModeEnabled()) lightDefault
     else darkDefault
 
-  def lightDefault: Skin
-  def darkDefault: Skin
+  def lightDefault: Default
+  def darkDefault: Default

--- a/core/src/main/scala/eu/joaocosta/interim/skins/HandleSkin.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/skins/HandleSkin.scala
@@ -7,7 +7,7 @@ trait HandleSkin:
   def handleArea(area: Rect): Rect
   def renderHandle(area: Rect, value: Rect, itemStatus: UiState.ItemStatus)(implicit uiState: UiState): Unit
 
-object HandleSkin extends DefaultSkin[HandleSkin]:
+object HandleSkin extends DefaultSkin:
   final case class Default(
       inactiveColor: Color,
       hotColor: Color,
@@ -26,13 +26,13 @@ object HandleSkin extends DefaultSkin[HandleSkin]:
         case UiState.ItemStatus(_, true, _) =>
           rectangle(handleArea, activeColor)
 
-  val lightDefault = Default(
+  val lightDefault: Default = Default(
     inactiveColor = ColorScheme.black,
     hotColor = ColorScheme.lightPrimary,
     activeColor = ColorScheme.lightPrimaryHighlight
   )
 
-  val darkDefault = Default(
+  val darkDefault: Default = Default(
     inactiveColor = ColorScheme.white,
     hotColor = ColorScheme.darkPrimary,
     activeColor = ColorScheme.darkPrimaryHighlight

--- a/core/src/main/scala/eu/joaocosta/interim/skins/SliderSkin.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/skins/SliderSkin.scala
@@ -10,7 +10,7 @@ trait SliderSkin:
       uiState: UiState
   ): Unit
 
-object SliderSkin extends DefaultSkin[SliderSkin]:
+object SliderSkin extends DefaultSkin:
   final case class Default(
       padding: Int,
       sliderSize: Int,
@@ -43,7 +43,7 @@ object SliderSkin extends DefaultSkin[SliderSkin]:
         case _ =>
           rectangle(sliderRect, activeColor)
 
-  val lightDefault = Default(
+  val lightDefault: Default = Default(
     padding = 8,
     sliderSize = 8,
     scrollbarColor = ColorScheme.lightGray,
@@ -52,7 +52,7 @@ object SliderSkin extends DefaultSkin[SliderSkin]:
     activeColor = ColorScheme.lightPrimaryHighlight
   )
 
-  val darkDefault = Default(
+  val darkDefault: Default = Default(
     padding = 8,
     sliderSize = 8,
     scrollbarColor = ColorScheme.darkGray,

--- a/core/src/main/scala/eu/joaocosta/interim/skins/TextInputSkin.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/skins/TextInputSkin.scala
@@ -7,7 +7,7 @@ trait TextInputSkin:
   def textInputArea(area: Rect): Rect
   def renderTextInput(area: Rect, value: String, itemStatus: UiState.ItemStatus)(implicit uiState: UiState): Unit
 
-object TextInputSkin extends DefaultSkin[TextInputSkin]:
+object TextInputSkin extends DefaultSkin:
   final case class Default(
       border: Int,
       fontSize: Int,
@@ -38,7 +38,7 @@ object TextInputSkin extends DefaultSkin[TextInputSkin]:
         TextLayout.VerticalAlignment.Center
       )
 
-  val lightDefault = Default(
+  val lightDefault: Default = Default(
     border = 4,
     fontSize = 8,
     inactiveColor = ColorScheme.darkGray,
@@ -48,7 +48,7 @@ object TextInputSkin extends DefaultSkin[TextInputSkin]:
     textColor = ColorScheme.black
   )
 
-  val darkDefault = Default(
+  val darkDefault: Default = Default(
     border = 4,
     fontSize = 8,
     inactiveColor = ColorScheme.lightGray,

--- a/core/src/main/scala/eu/joaocosta/interim/skins/WindowSkin.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/skins/WindowSkin.scala
@@ -11,7 +11,7 @@ trait WindowSkin:
   def panelArea(area: Rect): Rect
   def renderWindow(area: Rect, title: String)(implicit uiState: UiState): Unit
 
-object WindowSkin extends DefaultSkin[WindowSkin]:
+object WindowSkin extends DefaultSkin:
   final case class Default(
       fontSize: Int,
       textColor: Color,
@@ -31,14 +31,14 @@ object WindowSkin extends DefaultSkin[WindowSkin]:
       text(titleArea, textColor, title, fontSize, HorizontalAlignment.Center, VerticalAlignment.Center)
       rectangle(panelArea, panelColor)
 
-  val lightDefault = Default(
+  val lightDefault: Default = Default(
     fontSize = 8,
     textColor = ColorScheme.black,
     panelColor = ColorScheme.white,
     titleColor = ColorScheme.lightGray
   )
 
-  val darkDefault = Default(
+  val darkDefault: Default = Default(
     fontSize = 8,
     textColor = ColorScheme.white,
     panelColor = ColorScheme.black,


### PR DESCRIPTION
Changes the `DefaultSkin` shape and adds explicit types so that the default skins can be modified with `copy`.

Previously the type inference was not strict enough and would infer the super type (e.g. `WindowSkin.lightDefault` was inferred as `WindowSkin` instead of `WindowSkin.Default`).