### PR TITLE
Support `clip` operation

### DIFF
--- a/core/src/main/scala/eu/joaocosta/interim/Rect.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/Rect.scala
@@ -14,6 +14,10 @@ final case class Rect(x: Int, y: Int, w: Int, h: Int):
   def x2 = x + w
   def y2 = y + h
 
+  /** Returns true if the rectangle has no area
+    */
+  def isEmpty: Boolean = w <= 0 || h <= 0
+
   /** Checks if the mouse is over this area.
     */
   def isMouseOver(using inputState: InputState): Boolean =
@@ -50,3 +54,13 @@ final case class Rect(x: Int, y: Int, w: Int, h: Int):
     val minY = math.min(this.y1, that.y1)
     val maxY = math.max(this.y2, that.y2)
     Rect(x = minX, y = minY, w = maxX - minX, h = maxY - minY)
+
+  /** Intersects this rectangle with another one.
+    */
+  @alpha("intersect")
+  def &(that: Rect): Rect =
+    val maxX1 = math.max(this.x1, that.x1)
+    val maxY1 = math.max(this.y1, that.y1)
+    val minX2 = math.min(this.x2, that.x2)
+    val minY2 = math.min(this.y2, that.y2)
+    Rect(x = maxX1, y = maxY1, w = minX2 - maxX1, h = minY2 - maxY1)

--- a/core/src/main/scala/eu/joaocosta/interim/RenderOp.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/RenderOp.scala
@@ -20,6 +20,7 @@ enum RenderOp:
       color: Color,
       text: String,
       fontSize: Int,
+      textArea: Rect,
       horizontalAlignment: TextLayout.HorizontalAlignment,
       verticalAlignment: TextLayout.VerticalAlignment
   )
@@ -44,3 +45,10 @@ object RenderOp:
         charWidth: Char => Int = _ => textOp.fontSize,
         lineHeight: Int = (textOp.fontSize * 1.3).toInt
     ): List[DrawChar] = TextLayout.asDrawChars(textOp, charWidth, lineHeight)
+
+  extension (renderOp: RenderOp)
+    def clip(rect: Rect): RenderOp =
+      renderOp match
+        case dr: DrawRect => dr.copy(area = dr.area & rect)
+        case dt: DrawText => dt.copy(area = dt.area & rect)
+        case c: Custom[_] => c.copy(area = c.area & rect)

--- a/core/src/main/scala/eu/joaocosta/interim/TextLayout.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/TextLayout.scala
@@ -45,23 +45,24 @@ object TextLayout:
       remaining match
         case Nil =>
           alignV(
-            alignH(lineAcc, textOp.area.w, textOp.horizontalAlignment) ++ textAcc,
-            textOp.area.h,
+            alignH(lineAcc, textOp.textArea.w, textOp.horizontalAlignment) ++ textAcc,
+            textOp.textArea.h,
             textOp.verticalAlignment
           )
         case char :: cs =>
           val isNewline = char == '\n'
           val width     = charWidth(char)
-          if (dy + textOp.fontSize > textOp.area.h) layout(Nil, dx, dy, lineAcc, textAcc) // End here
-          else if (isNewline || width < textOp.area.w && dx + width > textOp.area.w)      // Newline
-            val line = alignH(lineAcc, textOp.area.h, textOp.horizontalAlignment)
+          if (dy + textOp.fontSize > textOp.textArea.h) layout(Nil, dx, dy, lineAcc, textAcc) // End here
+          else if (isNewline || width < textOp.textArea.w && dx + width > textOp.textArea.w)  // Newline
+            val line = alignH(lineAcc, textOp.textArea.h, textOp.horizontalAlignment)
             layout(if (isNewline) remaining.tail else remaining, 0, dy + lineHeight, Nil, line ++ textAcc)
           else
             val charArea = Rect(
-              x = textOp.area.x + dx,
-              y = textOp.area.y + dy,
+              x = textOp.textArea.x + dx,
+              y = textOp.textArea.y + dy,
               w = width,
               h = textOp.fontSize
             )
             layout(cs, dx + width, dy, RenderOp.DrawChar(charArea, textOp.color, char) :: lineAcc, textAcc)
-    layout(textOp.text.toList, 0, 0, Nil, Nil)
+
+    layout(textOp.text.toList, 0, 0, Nil, Nil).filter(char => (char.area & textOp.area) == char.area)

--- a/core/src/main/scala/eu/joaocosta/interim/UiState.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/UiState.scala
@@ -17,6 +17,7 @@ final class UiState private (
 ):
   def this() = this(None, None, None, new mutable.Queue[RenderOp]())
   override def clone(): UiState = new UiState(hotItem, activeItem, keyboardFocusItem, ops.clone())
+  def fork(): UiState           = new UiState(hotItem, activeItem, keyboardFocusItem, new mutable.Queue[RenderOp])
   private def registerItem(id: ItemId, area: Rect)(using inputState: InputState): UiState.ItemStatus =
     if (area.isMouseOver)
       hotItem = Some(id)
@@ -24,6 +25,12 @@ final class UiState private (
         activeItem = Some(id)
         keyboardFocusItem = Some(id)
     UiState.ItemStatus(hotItem == Some(id), activeItem == Some(id), keyboardFocusItem == Some(id))
+  def ++=(that: UiState): this.type =
+    this.hotItem = that.hotItem
+    this.activeItem = that.activeItem
+    this.keyboardFocusItem = that.keyboardFocusItem
+    this.ops ++= that.ops
+    this
 
 object UiState:
   /** Status of an item.

--- a/core/src/main/scala/eu/joaocosta/interim/UiState.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/UiState.scala
@@ -15,9 +15,7 @@ final class UiState private (
     private[interim] var keyboardFocusItem: Option[ItemId],
     private[interim] val ops: mutable.Queue[RenderOp]
 ):
-  def this() = this(None, None, None, new mutable.Queue[RenderOp]())
-  override def clone(): UiState = new UiState(hotItem, activeItem, keyboardFocusItem, ops.clone())
-  def fork(): UiState           = new UiState(hotItem, activeItem, keyboardFocusItem, new mutable.Queue[RenderOp])
+
   private def registerItem(id: ItemId, area: Rect)(using inputState: InputState): UiState.ItemStatus =
     if (area.isMouseOver)
       hotItem = Some(id)
@@ -25,6 +23,13 @@ final class UiState private (
         activeItem = Some(id)
         keyboardFocusItem = Some(id)
     UiState.ItemStatus(hotItem == Some(id), activeItem == Some(id), keyboardFocusItem == Some(id))
+
+  def this() = this(None, None, None, new mutable.Queue[RenderOp]())
+
+  override def clone(): UiState = new UiState(hotItem, activeItem, keyboardFocusItem, ops.clone())
+
+  def fork(): UiState = new UiState(hotItem, activeItem, keyboardFocusItem, new mutable.Queue[RenderOp])
+
   def ++=(that: UiState): this.type =
     this.hotItem = that.hotItem
     this.activeItem = that.activeItem

--- a/core/src/main/scala/eu/joaocosta/interim/api/Layouts.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Layouts.scala
@@ -1,6 +1,6 @@
 package eu.joaocosta.interim.api
 
-import eu.joaocosta.interim.Rect
+import eu.joaocosta.interim.{InputState, Rect, UiState}
 
 /** Objects containing all default layouts.
   *
@@ -9,6 +9,20 @@ import eu.joaocosta.interim.Rect
 object Layouts extends Layouts
 
 trait Layouts:
+
+  /** Clipped region.
+    *
+    * The body will be rendered only inside the clipped area. Input outside the area will also be ignored.
+    */
+  final def clip[T](area: Rect)(body: (InputState, UiState) ?=> T)(using inputState: InputState, uiState: UiState): T =
+    val newUiState = uiState.fork()
+    val newInputState =
+      if (area.isMouseOver) inputState
+      else inputState.copy(mouseX = Int.MinValue, mouseY = Int.MinValue)
+    val result = body(using newInputState, newUiState)
+    newUiState.ops.mapInPlace(_.clip(area))
+    uiState ++= newUiState
+    result
 
   /** Lays out the components in a grid where all elements have the same size, separated by a padding.
     *

--- a/core/src/main/scala/eu/joaocosta/interim/api/Layouts.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Layouts.scala
@@ -23,24 +23,28 @@ trait Layouts:
     * The body receives a `row: Vector[Rect]`, where `row(y)` is the rect of the y-th row.
     */
   final def rows[T](area: Rect, numRows: Int, padding: Int)(body: Vector[Rect] => T): T =
-    val rowSize = (area.h - (numRows - 1) * padding) / numRows
-    val vec = for
-      row <- (0 until numRows)
-      dy = row * (rowSize + padding)
-    yield Rect(area.x, area.y + dy, area.w, rowSize)
-    body(vec.toVector)
+    if (numRows <= 0) body(Vector.empty)
+    else
+      val rowSize = (area.h - (numRows - 1) * padding) / numRows
+      val vec = for
+        row <- (0 until numRows)
+        dy = row * (rowSize + padding)
+      yield Rect(area.x, area.y + dy, area.w, rowSize)
+      body(vec.toVector)
 
   /** Lays out the components in a sequence of columns where all elements have the same size, separated by a padding.
     *
     * The body receives a `column: Vector[Rect]`, where `column(y)` is the rect of the x-th column.
     */
   final def columns[T](area: Rect, numColumns: Int, padding: Int)(body: Vector[Rect] => T): T =
-    val columnSize = (area.w - (numColumns - 1) * padding) / numColumns
-    val vec = for
-      column <- (0 until numColumns)
-      dx = column * (columnSize + padding)
-    yield Rect(area.x + dx, area.y, columnSize, area.h)
-    body(vec.toVector)
+    if (numColumns <= 0) body(Vector.empty)
+    else
+      val columnSize = (area.w - (numColumns - 1) * padding) / numColumns
+      val vec = for
+        column <- (0 until numColumns)
+        dx = column * (columnSize + padding)
+      yield Rect(area.x + dx, area.y, columnSize, area.h)
+      body(vec.toVector)
 
   /** Lays out the components in a sequence of rows of different sizes, separated by a padding.
     *

--- a/core/src/main/scala/eu/joaocosta/interim/api/Primitives.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Primitives.scala
@@ -33,7 +33,7 @@ trait Primitives:
       uiState: UiState
   ): Unit =
     if (text.nonEmpty)
-      uiState.ops.addOne(RenderOp.DrawText(area, color, text, fontSize, horizontalAlignment, verticalAlignment))
+      uiState.ops.addOne(RenderOp.DrawText(area, color, text, fontSize, area, horizontalAlignment, verticalAlignment))
 
   /** Advanced operation to add a custom primitive to the list of render operations.
     *

--- a/core/src/test/scala/eu/joaocosta/interim/RectSpec.scala
+++ b/core/src/test/scala/eu/joaocosta/interim/RectSpec.scala
@@ -23,3 +23,15 @@ class RectSpec extends munit.FunSuite:
     val rect2 = Rect(15, 10, 10, 10)
     assertEquals(rect1 ++ rect2, Rect(10, 10, 15, 10))
     assertEquals(rect2 ++ rect1, Rect(10, 10, 15, 10))
+
+  test("intersect returns an empty rect when there's a gap"):
+    val rect1 = Rect(10, 10, 10, 10)
+    val rect2 = Rect(30, 10, 10, 10)
+    assertEquals((rect1 & rect2).isEmpty, true)
+    assertEquals((rect2 & rect1).isEmpty, true)
+
+  test("intersect shrinks two rects when they intersect"):
+    val rect1 = Rect(10, 10, 10, 10)
+    val rect2 = Rect(15, 10, 10, 10)
+    assertEquals(rect1 & rect2, Rect(15, 10, 5, 10))
+    assertEquals(rect2 & rect1, Rect(15, 10, 5, 10))

--- a/core/src/test/scala/eu/joaocosta/interim/UiStateSpec.scala
+++ b/core/src/test/scala/eu/joaocosta/interim/UiStateSpec.scala
@@ -47,3 +47,21 @@ class UiStateSpec extends munit.FunSuite:
     assertEquals(uiState.hotItem, Some(2))
     assertEquals(uiState.activeItem, Some(1))
     assertEquals(uiState.keyboardFocusItem, Some(1))
+
+  test("fork should create a new UiState with no ops, and merge them back with ++="):
+    val uiState: UiState = new UiState()
+    api.Primitives.rectangle(Rect(0, 0, 1, 1), Color(0, 0, 0))(using uiState)
+    assertEquals(uiState.ops.toList, List(RenderOp.DrawRect(Rect(0, 0, 1, 1), Color(0, 0, 0))))
+    val forked = uiState.fork()
+    assertEquals(forked.ops.toList, Nil)
+    api.Primitives.rectangle(Rect(0, 0, 1, 1), Color(1, 2, 3))(using forked)
+    assertEquals(uiState.ops.toList, List(RenderOp.DrawRect(Rect(0, 0, 1, 1), Color(0, 0, 0))))
+    assertEquals(forked.ops.toList, List(RenderOp.DrawRect(Rect(0, 0, 1, 1), Color(1, 2, 3))))
+    uiState ++= forked
+    assertEquals(
+      uiState.ops.toList,
+      List(
+        RenderOp.DrawRect(Rect(0, 0, 1, 1), Color(0, 0, 0)),
+        RenderOp.DrawRect(Rect(0, 0, 1, 1), Color(1, 2, 3))
+      )
+    )

--- a/core/src/test/scala/eu/joaocosta/interim/api/LayoutsSpec.scala
+++ b/core/src/test/scala/eu/joaocosta/interim/api/LayoutsSpec.scala
@@ -13,16 +13,31 @@ class LayoutsSpec extends munit.FunSuite:
       )
     assertEquals(areas, expected)
 
+  test("grid returns nothing for an empty grid"):
+    val areas    = Layouts.grid(Rect(10, 10, 100, 100), numRows = 0, numColumns = 0, padding = 8)(identity)
+    val expected = Vector.empty
+    assertEquals(areas, expected)
+
   test("rows correctly lays out elements in rows"):
     val areas = Layouts.rows(Rect(10, 10, 100, 100), numRows = 3, padding = 8)(identity)
     val expected =
       Vector(Rect(10, 10, 100, 28), Rect(10, 46, 100, 28), Rect(10, 82, 100, 28))
     assertEquals(areas, expected)
 
+  test("rows returns nothing for 0 rows"):
+    val areas    = Layouts.rows(Rect(10, 10, 100, 100), numRows = 0, padding = 8)(identity)
+    val expected = Vector.empty
+    assertEquals(areas, expected)
+
   test("columns correctly lays out elements in columns"):
     val areas = Layouts.columns(Rect(10, 10, 100, 100), numColumns = 3, padding = 8)(identity)
     val expected =
       Vector(Rect(10, 10, 28, 100), Rect(46, 10, 28, 100), Rect(82, 10, 28, 100))
+    assertEquals(areas, expected)
+
+  test("columns returns nothing for 0 columns"):
+    val areas    = Layouts.columns(Rect(10, 10, 100, 100), numColumns = 0, padding = 8)(identity)
+    val expected = Vector.empty
     assertEquals(areas, expected)
 
   test("dynamicRows correctly lays out elements in rows"):

--- a/core/src/test/scala/eu/joaocosta/interim/api/LayoutsSpec.scala
+++ b/core/src/test/scala/eu/joaocosta/interim/api/LayoutsSpec.scala
@@ -1,8 +1,31 @@
 package eu.joaocosta.interim.api
 
-import eu.joaocosta.interim.Rect
+import eu.joaocosta.interim.{Color, InputState, Rect, RenderOp, UiState}
 
 class LayoutsSpec extends munit.FunSuite:
+  test("clip correctly clips render ops"):
+    given uiState: UiState       = new UiState()
+    given inputState: InputState = InputState(0, 0, false, "")
+    Layouts.clip(Rect(10, 10, 10, 10)):
+      Primitives.rectangle(Rect(0, 0, 15, 15), Color(0, 0, 0))
+    assertEquals(uiState.ops.toList, List(RenderOp.DrawRect(Rect(10, 10, 5, 5), Color(0, 0, 0))))
+
+  test("clip ignores input outside the clip area"):
+    given uiState: UiState       = new UiState()
+    given inputState: InputState = InputState(5, 5, false, "")
+    val itemStatus =
+      Layouts.clip(Rect(10, 10, 10, 10)):
+        UiState.registerItem(1, Rect(0, 0, 15, 15))
+    assertEquals(itemStatus.hot, false)
+
+  test("clip considers input inside the clip area"):
+    given uiState: UiState       = new UiState()
+    given inputState: InputState = InputState(12, 12, false, "")
+    val itemStatus =
+      Layouts.clip(Rect(10, 10, 10, 10)):
+        UiState.registerItem(1, Rect(0, 0, 15, 15))
+    assertEquals(itemStatus.hot, true)
+
   test("grid correctly lays out elements in a grid"):
     val areas = Layouts.grid(Rect(10, 10, 100, 100), numRows = 3, numColumns = 2, padding = 8)(identity)
     val expected =

--- a/examples/snapshot/colorpicker.md
+++ b/examples/snapshot/colorpicker.md
@@ -88,13 +88,19 @@ def application(inputState: InputState) =
             resultDelta = 0
             query = newQuery
           val results = htmlColors.filter(_._1.toLowerCase.startsWith(query.toLowerCase))
-          dynamicColumns(area = newRow(maxSize), padding = 10) { newColumn =>
-            if (results.size > 5)
-              resultDelta = slider("result scroller", newColumn(-24), min = 0, max = results.size - 5)(resultDelta)
-            rows(area = newColumn(maxSize), numRows = 5, padding = 10) { rows =>
-              results.drop(resultDelta).zip(rows).foreach { case ((colorName, colorValue), row) =>
-                if (button(s"$colorName button", row, colorName))
-                  color = colorValue
+          val resultsArea = newRow(maxSize)
+          val buttonSize = 32
+          dynamicColumns(area = resultsArea, padding = 10) { newColumn =>
+            val resultsHeight = results.size * buttonSize
+            if (resultsHeight > resultsArea.h)
+              resultDelta = slider("result scroller", newColumn(-24), min = 0, max = resultsHeight - resultsArea.h)(resultDelta)
+            val clipArea = newColumn(maxSize)
+            clip(area = clipArea) {
+              rows(area = clipArea.copy(y = clipArea.y - resultDelta, h = resultsHeight), numRows = results.size, padding = 10) { rows =>
+                results.zip(rows).foreach { case ((colorName, colorValue), row) =>
+                  if (button(s"$colorName button", row, colorName))
+                    color = colorValue
+                }
               }
             }
           }


### PR DESCRIPTION
Adds a new `clip` block to the layouts that ensures that all render ops are limited to that space and inputs outside of that space are ignored.

This PR also fixes some bugs with the other layouts (when the number of rows/columns is empty) and adds fork/join operations to `UiState` that might allow layouts where the parent size depends on the children.

Closes #9 