### PR TITLE
Encode RenderOp as a sealed trait

### DIFF
--- a/core/src/main/scala/eu/joaocosta/interim/api/Layouts.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Layouts.scala
@@ -20,7 +20,7 @@ trait Layouts:
       if (area.isMouseOver) inputState
       else inputState.copy(mouseX = Int.MinValue, mouseY = Int.MinValue)
     val result = body(using newInputState, newUiState)
-    newUiState.ops.mapInPlace(_.clip(area))
+    newUiState.ops.mapInPlace(_.clip(area)).filterInPlace(!_.area.isEmpty)
     uiState ++= newUiState
     result
 


### PR DESCRIPTION
Encodes RenderOp as a sealed trait instead of an enum.

This allows for slightly better type inference, and to write some code that applies to all render ops.