### PR TITLE
Add `Ref` abstraction

### DIFF
--- a/core/src/main/scala/eu/joaocosta/interim/api/Panels.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Panels.scala
@@ -30,7 +30,7 @@ trait Panels:
     */
   final def window[T](
       id: ItemId,
-      area: Rect,
+      area: Rect | Ref[Rect],
       title: String,
       movable: Boolean = false,
       skin: WindowSkin = WindowSkin.default(),
@@ -38,13 +38,14 @@ trait Panels:
   )(
       body: Rect => T
   ): Components.Component[(T, Rect)] =
-    skin.renderWindow(area, title)
-    val nextArea =
+    val oldArea: Rect = Ref.get(area)
+    skin.renderWindow(oldArea, title)
+    val nextArea: Rect =
       if (movable)
         Components.moveHandle(
           id |> "internal_move_handle",
-          skin.titleTextArea(area),
+          skin.titleTextArea(oldArea),
           handleSkin
         )(area)
-      else area
-    (body(skin.panelArea(area)), nextArea)
+      else oldArea
+    (body(skin.panelArea(oldArea)), nextArea)

--- a/core/src/main/scala/eu/joaocosta/interim/api/Ref.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Ref.scala
@@ -1,0 +1,40 @@
+package eu.joaocosta.interim.api
+
+/** A mutable reference to a variable.
+  *
+  * When a function receives a Ref as an argument, it will probably mutate it.
+  */
+final case class Ref[T](var value: T) {
+
+  /** Assigns a value to this Ref.
+    * Shorthand for `ref.value = x`
+    */
+  def :=(newValue: T): this.type =
+    value = newValue
+    this
+}
+
+object Ref {
+
+  /** Gets a value from a Ref or from a plain value.
+    */
+  inline def get[T](x: T | Ref[T]): T = x match
+    case value: T    => value
+    case ref: Ref[T] => ref.value
+
+  /** Sets a value from a Ref or from a plain value.
+    *
+    * The new value is returned. Refs will be mutated while immutable values will not.
+    */
+  inline def set[T](x: T | Ref[T], v: T): T = modify(x, _ => v)
+
+  /** Modifies a value from a Ref or from a plain value.
+    *
+    * The new value is returned. Refs will be mutated while immutable values will not.
+    */
+  inline def modify[T](x: T | Ref[T], f: T => T): T = x match
+    case value: T => f(value)
+    case ref: Ref[T] =>
+      ref.value = f(ref.value)
+      ref.value
+}

--- a/examples/snapshot/colorpicker.md
+++ b/examples/snapshot/colorpicker.md
@@ -34,12 +34,13 @@ This one is more of a show off of what you can do.
 
 ```scala
 import eu.joaocosta.interim.*
+import eu.joaocosta.interim.api.Ref
 
 val uiState = new UiState()
 
-var colorPickerArea = Rect(x = 10, y = 10, w = 210, h = 210)
-var colorSearchArea = Rect(x = 300, y = 10, w = 210, h = 210)
-var resultDelta     = 0
+val colorPickerArea = Ref(Rect(x = 10, y = 10, w = 210, h = 210))
+val colorSearchArea = Ref(Rect(x = 300, y = 10, w = 210, h = 210))
+val resultDelta     = Ref(0)
 var color           = Color(0, 0, 0)
 var query           = ""
 
@@ -63,12 +64,12 @@ val htmlColors = List(
 )
 
 def application(inputState: InputState) =
-  import eu.joaocosta.interim.InterIm._
+  import eu.joaocosta.interim.InterIm.*
   def textColor =
     if (skins.ColorScheme.darkModeEnabled()) skins.ColorScheme.white
     else skins.ColorScheme.black
   ui(inputState, uiState):
-    colorPickerArea = window(id = "color picker", area = colorPickerArea, title = "Color Picker", movable = true) {
+    window(id = "color picker", area = colorPickerArea, title = "Color Picker", movable = true) {
       area =>
         rows(area = area.shrink(5), numRows = 5, padding = 10) { row =>
           rectangle(row(0), color)
@@ -78,14 +79,14 @@ def application(inputState: InputState) =
           val b = slider("blue slider", row(4), min = 0, max = 255)(color.b)
           color = Color(r, g, b)
         }
-    }._2
+    }
 
-    colorSearchArea = window(id = "color search", area = colorSearchArea, title = "Color Search", movable = true) {
+    window(id = "color search", area = colorSearchArea, title = "Color Search", movable = true) {
       area =>
         dynamicRows(area = area.shrink(5), padding = 10) { newRow =>
           val newQuery = textInput("query", newRow(32))(query)
           if (query != newQuery)
-            resultDelta = 0
+            resultDelta := 0
             query = newQuery
           val results = htmlColors.filter(_._1.toLowerCase.startsWith(query.toLowerCase))
           val resultsArea = newRow(maxSize)
@@ -93,10 +94,10 @@ def application(inputState: InputState) =
           dynamicColumns(area = resultsArea, padding = 10) { newColumn =>
             val resultsHeight = results.size * buttonSize
             if (resultsHeight > resultsArea.h)
-              resultDelta = slider("result scroller", newColumn(-24), min = 0, max = resultsHeight - resultsArea.h)(resultDelta)
+              slider("result scroller", newColumn(-24), min = 0, max = resultsHeight - resultsArea.h)(resultDelta)
             val clipArea = newColumn(maxSize)
             clip(area = clipArea) {
-              rows(area = clipArea.copy(y = clipArea.y - resultDelta, h = resultsHeight), numRows = results.size, padding = 10) { rows =>
+              rows(area = clipArea.copy(y = clipArea.y - resultDelta.value, h = resultsHeight), numRows = results.size, padding = 10) { rows =>
                 results.zip(rows).foreach { case ((colorName, colorValue), row) =>
                   if (button(s"$colorName button", row, colorName))
                     color = colorValue
@@ -105,7 +106,7 @@ def application(inputState: InputState) =
             }
           }
         }
-    }._2
+    }
 
     window(id = "settings", area = Rect(10, 430, 250, 40), title = "Settings", movable = false) { area =>
       dynamicColumns(area = area.shrink(5), padding = 10) { newColumn =>

--- a/examples/snapshot/windows.md
+++ b/examples/snapshot/windows.md
@@ -84,7 +84,7 @@ handle the mutation themselves.
 
 The example above could also be written as:
 
-```scala
+```scala reset
 import eu.joaocosta.interim.*
 import eu.joaocosta.interim.api.Ref
 

--- a/examples/snapshot/windows.md
+++ b/examples/snapshot/windows.md
@@ -68,3 +68,51 @@ Let's run it:
 ```scala
 MinartBackend.run(application)
 ```
+
+## Mutable references
+
+In some situations, even a mutable style can be quite verbose.
+
+In the example above, we only care about the window area, so we are dropping one of the values with `._2`, but if we
+wanted to keep the value we would need to create a temporary variable and then mutate our state with the result.
+
+Usually, immediate mode UIs solve this by using out parameters, and this is exactly what InterIm provides with the `Ref`
+abstraction.
+
+A `Ref` is simply a wrapper for a mutable value (`final case class Ref[T](var value: T)`). That way, components can
+handle the mutation themselves.
+
+The example above could also be written as:
+
+```scala
+import eu.joaocosta.interim.*
+import eu.joaocosta.interim.api.Ref
+
+val uiState = new UiState()
+
+val windowArea = Ref(Rect(x = 10, y = 10, w = 110, h = 50)) // Now a val instead of a var
+var counter    = 0
+
+def application(inputState: InputState) =
+  import eu.joaocosta.interim.InterIm._
+  ui(inputState, uiState):
+    window(id = "window", area = windowArea, title = "My Counter", movable = true) { area =>
+      columns(area = area.shrink(5), numColumns = 3, padding = 10) { column =>
+        if (button(id = "minus", area = column(0), label = "-"))
+          counter = counter - 1
+        text(
+          area = column(1),
+          color = Color(0, 0, 0),
+          text = counter.toString,
+          fontSize = 8,
+          horizontalAlignment = centerHorizontally,
+          verticalAlignment = centerVertically
+        )
+        if (button(id = "plus", area = column(2), label = "+"))
+          counter = counter + 1
+      }
+    }
+```
+
+Be aware that, while the code is more concise, coding with out parameters can lead to confusing code where it's hard
+to find out where a value is being mutated. It's up to you to decide when to use `Ref`s and when to use plain values.


### PR DESCRIPTION
Adds a `Ref` abstraction (for mutable references) to support out parameters.

While usually frowned upon, this allows the API to be closer to other immediate mode GUIs.
Also, the old interface still works just fine.