### PR TITLE
Add a number to each example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@ Here you'll find multiple examples that also work as a tutorial to get started w
 
 Each example is prefixed by a number, which indicate the recommended order for each lesson.
 
-For instance, to run the first example, just run `scala-cli 01-intro.sc example-minart-backend.scala`.
+For instance, to run the first example, just run `scala-cli 01-intro.md example-minart-backend.scala`.
 
 The examples in `examples/release` target the latest released version, while the examples in `examples/snapshot` target
 the code in the repository. If you are starting out, it is recommended that you look at the examples in the `release`

--- a/examples/snapshot/1-intro.md
+++ b/examples/snapshot/1-intro.md
@@ -7,7 +7,7 @@ Welcome to the InterIm tutorial!
 You can run the code in this file (and other tutorials) with:
 
 ```bash
-scala-cli intro.md example-minart-backend.scala
+scala-cli 1-intro.md example-minart-backend.scala
 ```
 
 Other examples can be run in a similar fashion

--- a/examples/snapshot/2-layout.md
+++ b/examples/snapshot/2-layout.md
@@ -7,7 +7,7 @@ Welcome to the InterIm tutorial!
 You can run the code in this file (and other tutorials) with:
 
 ```bash
-scala-cli layout.md example-minart-backend.scala
+scala-cli 2-layout.md example-minart-backend.scala
 ```
 
 Other examples can be run in a similar fashion

--- a/examples/snapshot/3-windows.md
+++ b/examples/snapshot/3-windows.md
@@ -7,7 +7,7 @@ Welcome to the InterIm tutorial!
 You can run the code in this file (and other tutorials) with:
 
 ```bash
-scala-cli windows.md example-minart-backend.scala
+scala-cli 3-windows.md example-minart-backend.scala
 ```
 
 Other examples can be run in a similar fashion

--- a/examples/snapshot/4-colorpicker.md
+++ b/examples/snapshot/4-colorpicker.md
@@ -7,7 +7,7 @@ Welcome to the InterIm tutorial!
 You can run the code in this file (and other tutorials) with:
 
 ```bash
-scala-cli colorpicker.md example-minart-backend.scala
+scala-cli 4-colorpicker.md example-minart-backend.scala
 ```
 
 Other examples can be run in a similar fashion


### PR DESCRIPTION
As of scala-cli 1.0.2, markdown files can start with a number.

This way, it's easy to follow the tutorial in the correct order.