### PR TITLE
Add radio buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ To know more about the library and how to get started check the [examples](https
 - Text
 - Buttons
 - Checkboxes
+- Radio Buttons
 - Sliders
 - Text Input
 - Movable components (including windows)

--- a/core/src/main/scala/eu/joaocosta/interim/api/Components.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Components.scala
@@ -39,6 +39,27 @@ trait Components:
     if (itemStatus.hot && itemStatus.active && summon[InputState].mouseDown == false) Ref.modify(value, v => !v)
     else Ref.get(value)
 
+  /** Radio button component. Returns value currently selected.
+    *
+    * @param buttonIndex the index of this button (value that this button returns when selected)
+    * @param label text label to show on this button
+    */
+  final def radioButton(
+      id: ItemId,
+      area: Rect,
+      buttonIndex: Int,
+      label: String,
+      skin: ButtonSkin = ButtonSkin.default()
+  )(value: Int | Ref[Int]): Component[Int] =
+    val buttonArea = skin.buttonArea(area)
+    val itemStatus = UiState.registerItem(id, buttonArea)
+    val newValue =
+      if (itemStatus.hot && itemStatus.active && summon[InputState].mouseDown == false) Ref.set[Int](value, buttonIndex)
+      else Ref.get[Int](value)
+    if (newValue == buttonIndex) skin.renderButton(area, label, itemStatus.copy(hot = true, active = true))
+    else (skin.renderButton(area, label, itemStatus))
+    newValue
+
   /** Slider component. Returns the current position of the slider, between min and max.
     *
     * @param min minimum value for this slider

--- a/core/src/main/scala/eu/joaocosta/interim/api/Ref.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Ref.scala
@@ -33,8 +33,18 @@ object Ref {
     * The new value is returned. Refs will be mutated while immutable values will not.
     */
   inline def modify[T](x: T | Ref[T], f: T => T): T = x match
-    case value: T => f(value)
+    case value: T =>
+      f(value)
     case ref: Ref[T] =>
       ref.value = f(ref.value)
       ref.value
+
+  /** Creates a ref that can be used inside a block and returns that value.
+    *
+    * Useful to set temporary mutable variables.
+    */
+  def withRef[T](initialValue: T)(block: Ref[T] => Unit): T =
+    val ref = Ref(initialValue)
+    block(ref)
+    ref.value
 }

--- a/core/src/main/scala/eu/joaocosta/interim/api/Ref.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Ref.scala
@@ -39,7 +39,7 @@ object Ref {
       ref.value = f(ref.value)
       ref.value
 
-  /** Creates a ref that can be used inside a block and returns that value.
+  /** Creates a Ref that can be used inside a block and returns that value.
     *
     * Useful to set temporary mutable variables.
     */
@@ -47,4 +47,10 @@ object Ref {
     val ref = Ref(initialValue)
     block(ref)
     ref.value
+
+  /** Wraps this value into a Ref and passes it to a block, returning the final value of the ref.
+    *
+    * Useful to set temporary mutable variables.
+    */
+  extension [T](x: T) def asRef(block: Ref[T] => Unit): T = withRef(x)(block)
 }


### PR DESCRIPTION
Adds a new `radioButton` component.

Also adds some new methods to `Ref` so that radio button groups are easier to define with local mutability, for example, like this:

```scala
val nextValue = currentValue.asRef { valueRef =>
  radioButton(id = "0", area = column(0), buttonIndex = 0, label = "0")(valueRef)
  radioButton(id = "1", area = column(1), buttonIndex = 1, label = "1")(valueRef)
  radioButton(id = "2", area = column(2), buttonIndex = 2, label = "2")(valueRef)
}
```

As opposed to
```scala
val nextValue = {
  val valueRef= Ref(currentValue)
  radioButton(id = "0", area = column(0), buttonIndex = 0, label = "0")(valueRef)
  radioButton(id = "1", area = column(1), buttonIndex = 1, label = "1")(valueRef)
  radioButton(id = "2", area = column(2), buttonIndex = 2, label = "2")(valueRef)
  valueRef.value
}
```

or

```scala
val nextValue = {
  var _nextValue = currentValue
  _nextValue = radioButton(id = "0", area = column(0), buttonIndex = 0, label = "0")(_nextValue)
  _nextValue = radioButton(id = "1", area = column(1), buttonIndex = 1, label = "1")(_nextValue)
  _nextValue = radioButton(id = "2", area = column(2), buttonIndex = 2, label = "2")(_nextValue)
  _nextValue
}
```