### PR TITLE
Refactor Ref operations

### DIFF
--- a/core/src/main/scala/eu/joaocosta/interim/ItemId.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/ItemId.scala
@@ -1,6 +1,6 @@
 package eu.joaocosta.interim
 
-import scala.annotation.alpha
+import scala.annotation.targetName
 
 /** Identifier of an item. Should be unique for each item.
   *
@@ -22,6 +22,6 @@ object ItemId:
   /** Operator to add a child to an item id. Useful for composite components.
     */
   extension (parentId: ItemId)
-    @alpha("addChild")
+    @targetName("addChild")
     def |>(childId: ItemId): ItemId =
       parentId.toIdList ++ childId.toIdList

--- a/core/src/main/scala/eu/joaocosta/interim/api/Ref.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Ref.scala
@@ -1,44 +1,32 @@
 package eu.joaocosta.interim.api
 
+import scala.annotation.targetName
 import scala.deriving.Mirror
 
 /** A mutable reference to a variable.
   *
   * When a function receives a Ref as an argument, it will probably mutate it.
   */
-final case class Ref[T](var value: T):
+final case class Ref[T](private var value: T):
+  /** Returns the value of this Ref.
+    */
+  def get: T = value
 
   /** Assigns a value to this Ref.
-    * Shorthand for `ref.value = x`
     */
+  @targetName("set")
   def :=(newValue: T): this.type =
     value = newValue
     this
 
+  /** Modifies the value pf this Ref.
+    * Shorthand for `ref := f(ref.value)`
+    */
+  def modify(f: T => T): this.type =
+    value = f(value)
+    this
+
 object Ref:
-
-  /** Gets a value from a Ref or from a plain value.
-    */
-  inline def get[T](x: T | Ref[T]): T = inline x match
-    case value: T    => value
-    case ref: Ref[T] => ref.value
-
-  /** Sets a value from a Ref or from a plain value.
-    *
-    * The new value is returned. Refs will be mutated while immutable values will not.
-    */
-  inline def set[T](x: T | Ref[T], v: T): T = modify(x, _ => v)
-
-  /** Modifies a value from a Ref or from a plain value.
-    *
-    * The new value is returned. Refs will be mutated while immutable values will not.
-    */
-  inline def modify[T](x: T | Ref[T], f: T => T): T = inline x match
-    case value: T =>
-      f(value)
-    case ref: Ref[T] =>
-      ref.value = f(ref.value)
-      ref.value
 
   /** Creates a Ref that can be used inside a block and returns that value.
     *

--- a/core/src/test/scala/eu/joaocosta/interim/api/RefSpec.scala
+++ b/core/src/test/scala/eu/joaocosta/interim/api/RefSpec.scala
@@ -1,40 +1,21 @@
 package eu.joaocosta.interim.api
 
 class RefSpec extends munit.FunSuite:
-  test("A Ref value can be correctly set and retrieved with := and value"):
+  test("A Ref value can be correctly set and retrieved with := and get"):
     val x = Ref(1)
-    assertEquals(x.value, 1)
+    assertEquals(x.get, 1)
     x := 2
-    assertEquals(x.value, 2)
-    x.value = 3
-    assertEquals(x.value, 3)
+    assertEquals(x.get, 2)
 
-  test("Ref values and raw values can be fetched with Ref.get"):
+  test("Ref values can be modified with modify"):
     val x = Ref(1)
-    val y = 1
-    assertEquals(Ref.get[Int](x), Ref.get[Int](y))
 
-  test("Ref values and raw values can be set with Ref.set"):
-    val x = Ref(1)
-    val y = 1
-
-    assertEquals(Ref.set[Int](x, 2), 2)
-    assertEquals(Ref.set[Int](y, 2), 2)
-    assertEquals(x.value, 2)
-    assertEquals(y, 1)
-
-  test("Ref values and raw values can be modified with Ref.modify"):
-    val x = Ref(1)
-    val y = 1
-
-    assertEquals(Ref.modify[Int](x, _ + 1), 2)
-    assertEquals(Ref.modify[Int](y, _ + 1), 2)
-    assertEquals(x.value, 2)
-    assertEquals(y, 1)
+    assertEquals(x.modify(_ + 1).get, 2)
+    assertEquals(x.get, 2)
 
   test("withRef allows to use a temporary Ref value"):
     val result = Ref.withRef(0) { ref =>
-      Ref.modify[Int](ref, _ + 2)
+      ref.modify(_ + 2)
     }
     assertEquals(result, 2)
 
@@ -51,7 +32,7 @@ class RefSpec extends munit.FunSuite:
   test("asRef allows to use a temporary Ref value"):
     import Ref.asRef
     val result = 0.asRef { ref =>
-      Ref.modify[Int](ref, _ + 2)
+      ref.modify(_ + 2)
     }
     assertEquals(result, 2)
 

--- a/examples/snapshot/4-refs.md
+++ b/examples/snapshot/4-refs.md
@@ -89,17 +89,17 @@ def applicationRef(inputState: InputState, appState: AppState) =
       window(id = "window", area = windowArea, title = "My Counter", movable = true) { area =>
         columns(area = area.shrink(5), numColumns = 3, padding = 10) { column =>
           if (button(id = "minus", area = column(0), label = "-"))
-            counter := counter.value - 1 // Counter is a Ref, so we need to use :=
+            counter := counter.get - 1 // Counter is a Ref, so we need to use :=
           text(
             area = column(1),
             color = Color(0, 0, 0),
-            text = counter.value.toString,  // Counter is a Ref, so we need to use .value
+            text = counter.get.toString,  // Counter is a Ref, so we need to use .get
             fontSize = 8,
             horizontalAlignment = centerHorizontally,
             verticalAlignment = centerVertically
           )
           if (button(id = "plus", area = column(2), label = "+"))
-            counter := counter.value + 1  // Counter is a Ref, so we need to use :=
+            counter := counter.get + 1  // Counter is a Ref, so we need to use :=
         }
       }
     }

--- a/examples/snapshot/5-colorpicker.md
+++ b/examples/snapshot/5-colorpicker.md
@@ -79,11 +79,11 @@ def application(inputState: InputState, appState: AppState) =
       window(id = "color picker", area = colorPickerArea, title = "Color Picker", movable = true) {
         area =>
           rows(area = area.shrink(5), numRows = 5, padding = 10) { row =>
-            rectangle(row(0), color.value)
-            text(row(1), textColor, color.value.toString, 8, verticalAlignment = centerVertically)
-            val r = slider("red slider", row(2), min = 0, max = 255)(color.value.r)
-            val g = slider("green slider", row(3), min = 0, max = 255)(color.value.g)
-            val b = slider("blue slider", row(4), min = 0, max = 255)(color.value.b)
+            rectangle(row(0), color.get)
+            text(row(1), textColor, color.get.toString, 8, verticalAlignment = centerVertically)
+            val r = slider("red slider", row(2), min = 0, max = 255)(color.get.r)
+            val g = slider("green slider", row(3), min = 0, max = 255)(color.get.g)
+            val b = slider("blue slider", row(4), min = 0, max = 255)(color.get.b)
             color := Color(r, g, b)
           }
       }
@@ -91,10 +91,10 @@ def application(inputState: InputState, appState: AppState) =
       window(id = "color search", area = colorSearchArea, title = "Color Search", movable = true) {
         area =>
           dynamicRows(area = area.shrink(5), padding = 10) { newRow =>
-            val oldQuery = query.value
+            val oldQuery = query.get
             textInput("query", newRow(16))(query)
-            if (query.value != oldQuery) resultDelta := 0
-            val results = htmlColors.filter(_._1.toLowerCase.startsWith(query.value.toLowerCase))
+            if (query.get != oldQuery) resultDelta := 0
+            val results = htmlColors.filter(_._1.toLowerCase.startsWith(query.get.toLowerCase))
             val resultsArea = newRow(maxSize)
             val buttonSize = 32
             dynamicColumns(area = resultsArea, padding = 10) { newColumn =>
@@ -103,7 +103,7 @@ def application(inputState: InputState, appState: AppState) =
                 slider("result scroller", newColumn(-16), min = 0, max = resultsHeight - resultsArea.h)(resultDelta)
               val clipArea = newColumn(maxSize)
               clip(area = clipArea) {
-                rows(area = clipArea.copy(y = clipArea.y - resultDelta.value, h = resultsHeight), numRows = results.size, padding = 10) { rows =>
+                rows(area = clipArea.copy(y = clipArea.y - resultDelta.get, h = resultsHeight), numRows = results.size, padding = 10) { rows =>
                   results.zip(rows).foreach { case ((colorName, colorValue), row) =>
                     if (button(s"$colorName button", row, colorName))
                       color := colorValue


### PR DESCRIPTION
Removes the `Ref.get`/`Ref.set`/`Ref.modify` operations in favor of `Ref#get`/`Ref#:=`/`Ref#modify`.

There's really not much of a reason to accept both `Ref`s and raw values, and those operations were quite verbose and annoying to use.

This PR also makes `Ref.value` private. The rationale being:
- It's a bit awkward to have multiple ways to get/set a value
- In practice, I notice that in a lot of situations it's helpful to have a `value: Ref[T]` variable, and `value.value` just looks off
- I've been thinking about the possibility or a `Ref` that does not actually hold a value, but it's more like a lens. Not sure if I'll ever go ahead with that idea, though.