### PR TITLE
Add Z sort

### DIFF
--- a/core/src/main/scala/eu/joaocosta/interim/InterIm.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/InterIm.scala
@@ -21,6 +21,7 @@ object InterIm extends api.Primitives with api.Layouts with api.Components with 
   ): (List[RenderOp], T) =
     // prepare
     uiContext.ops.clear()
+    uiContext.currentZ = 0
     uiContext.hotItem = None
     if (inputState.mouseDown) uiContext.keyboardFocusItem = None
     // run
@@ -28,4 +29,4 @@ object InterIm extends api.Primitives with api.Layouts with api.Components with 
     // finish
     if (!inputState.mouseDown) uiContext.activeItem = None
     // return
-    (uiContext.ops.toList, res)
+    (uiContext.getOrderedOps(), res)

--- a/core/src/main/scala/eu/joaocosta/interim/UiContext.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/UiContext.scala
@@ -11,19 +11,19 @@ import scala.collection.mutable
   */
 final class UiContext private (
     private[interim] var currentZ: Int,
-    private[interim] var hotItem: Option[ItemId],
+    private[interim] var hotItem: Option[(Int, ItemId)],
     private[interim] var activeItem: Option[ItemId],
     private[interim] var keyboardFocusItem: Option[ItemId],
     private[interim] val ops: mutable.TreeMap[Int, mutable.Queue[RenderOp]]
 ):
 
   private def registerItem(id: ItemId, area: Rect)(using inputState: InputState): UiContext.ItemStatus =
-    if (area.isMouseOver)
-      hotItem = Some(id)
+    if (area.isMouseOver && hotItem.forall((hotZ, _) => hotZ <= currentZ))
+      hotItem = Some(currentZ -> id)
       if ((activeItem == None || activeItem == Some(id)) && inputState.mouseDown)
         activeItem = Some(id)
         keyboardFocusItem = Some(id)
-    UiContext.ItemStatus(hotItem == Some(id), activeItem == Some(id), keyboardFocusItem == Some(id))
+    UiContext.ItemStatus(hotItem.map(_._2) == Some(id), activeItem == Some(id), keyboardFocusItem == Some(id))
 
   private[interim] def getOrderedOps(): List[RenderOp] =
     ops.values.toList.flatten

--- a/core/src/main/scala/eu/joaocosta/interim/UiContext.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/UiContext.scala
@@ -17,10 +17,12 @@ final class UiContext private (
     private[interim] val ops: mutable.TreeMap[Int, mutable.Queue[RenderOp]]
 ):
 
-  private def registerItem(id: ItemId, area: Rect)(using inputState: InputState): UiContext.ItemStatus =
+  private def registerItem(id: ItemId, area: Rect, passive: Boolean)(using
+      inputState: InputState
+  ): UiContext.ItemStatus =
     if (area.isMouseOver && hotItem.forall((hotZ, _) => hotZ <= currentZ))
       hotItem = Some(currentZ -> id)
-      if ((activeItem == None || activeItem == Some(id)) && inputState.mouseDown)
+      if (!passive && (activeItem == None || activeItem == Some(id)) && inputState.mouseDown)
         activeItem = Some(id)
         keyboardFocusItem = Some(id)
     UiContext.ItemStatus(hotItem.map(_._2) == Some(id), activeItem == Some(id), keyboardFocusItem == Some(id))
@@ -64,10 +66,17 @@ object UiContext:
     *
     * Note that this is only required when creating new components.
     *
+    * @param id Item ID to register
+    * @param area the area of this component
+    * @param passive passive items are items such as windows that are never marked as active,
+    *                they are just registered to block components under them.
     * @return the item status of the registered component.
     */
-  def registerItem(id: ItemId, area: Rect)(using uiContext: UiContext, inputState: InputState): UiContext.ItemStatus =
-    uiContext.registerItem(id, area)
+  def registerItem(id: ItemId, area: Rect, passive: Boolean = false)(using
+      uiContext: UiContext,
+      inputState: InputState
+  ): UiContext.ItemStatus =
+    uiContext.registerItem(id, area, passive)
 
   /** Applies the operations in a code block at a specified z-index
     *  (higher z-indices show on front of lower z-indices).

--- a/core/src/main/scala/eu/joaocosta/interim/api/Layouts.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Layouts.scala
@@ -22,7 +22,7 @@ trait Layouts:
       if (area.isMouseOver) inputState
       else inputState.copy(mouseX = Int.MinValue, mouseY = Int.MinValue)
     val result = body(using newInputState, newUiContext)
-    newUiContext.ops.mapInPlace(_.clip(area)).filterInPlace(!_.area.isEmpty)
+    newUiContext.ops.foreach(_._2.mapInPlace(_.clip(area)).filterInPlace(!_.area.isEmpty))
     uiContext ++= newUiContext
     result
 

--- a/core/src/main/scala/eu/joaocosta/interim/api/Layouts.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Layouts.scala
@@ -13,6 +13,8 @@ trait Layouts:
   /** Clipped region.
     *
     * The body will be rendered only inside the clipped area. Input outside the area will also be ignored.
+    *
+    * Note that the clip will only be applied to elements in the current Z-index.
     */
   final def clip[T](area: Rect)(
       body: (InputState, UiContext) ?=> T
@@ -22,7 +24,7 @@ trait Layouts:
       if (area.isMouseOver) inputState
       else inputState.copy(mouseX = Int.MinValue, mouseY = Int.MinValue)
     val result = body(using newInputState, newUiContext)
-    newUiContext.ops.foreach(_._2.mapInPlace(_.clip(area)).filterInPlace(!_.area.isEmpty))
+    newUiContext.ops.get(newUiContext.currentZ).foreach(_.mapInPlace(_.clip(area)).filterInPlace(!_.area.isEmpty))
     uiContext ++= newUiContext
     result
 

--- a/core/src/main/scala/eu/joaocosta/interim/api/Panels.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Panels.scala
@@ -42,6 +42,7 @@ trait Panels:
       case ref: Ref[Rect] => ref
       case v: Rect        => Ref(v)
     }
+    UiContext.registerItem(id, areaRef.get, passive = true)
     skin.renderWindow(areaRef.get, title)
     val res = body(skin.panelArea(areaRef.get))
     if (movable)

--- a/core/src/main/scala/eu/joaocosta/interim/api/Primitives.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Primitives.scala
@@ -13,7 +13,7 @@ trait Primitives:
   /** Draws a rectangle filling a the specified area with a color.
     */
   final def rectangle(area: Rect, color: Color)(using uiContext: UiContext): Unit =
-    uiContext.ops.addOne(RenderOp.DrawRect(area, color))
+    uiContext.pushRenderOp(RenderOp.DrawRect(area, color))
 
   /** Draws a block of text in the specified area with a color.
     *
@@ -33,7 +33,7 @@ trait Primitives:
       uiContext: UiContext
   ): Unit =
     if (text.nonEmpty)
-      uiContext.ops.addOne(RenderOp.DrawText(area, color, text, font, area, horizontalAlignment, verticalAlignment))
+      uiContext.pushRenderOp(RenderOp.DrawText(area, color, text, font, area, horizontalAlignment, verticalAlignment))
 
   /** Advanced operation to add a custom primitive to the list of render operations.
     *
@@ -43,4 +43,12 @@ trait Primitives:
     * @param data custom value to be interpreted by the backend.
     */
   final def custom[T](area: Rect, color: Color, data: T)(using uiContext: UiContext): Unit =
-    uiContext.ops.addOne(RenderOp.Custom(area, color, data))
+    uiContext.pushRenderOp(RenderOp.Custom(area, color, data))
+
+  /** Applies the operations in a code block at the next z-index. */
+  def onTop[T](body: (UiContext) ?=> T)(using uiContext: UiContext): T =
+    UiContext.withZIndex(uiContext.currentZ + 1)(body)
+
+  /** Applies the operations in a code block at the previous z-index. */
+  def onBottom[T](body: (UiContext) ?=> T)(using uiContext: UiContext): T =
+    UiContext.withZIndex(uiContext.currentZ - 1)(body)

--- a/core/src/test/scala/eu/joaocosta/interim/UiContextSpec.scala
+++ b/core/src/test/scala/eu/joaocosta/interim/UiContextSpec.scala
@@ -19,7 +19,7 @@ class UiContextSpec extends munit.FunSuite:
     assertEquals(itemStatus.hot, true)
     assertEquals(itemStatus.active, false)
     assertEquals(itemStatus.keyboardFocus, false)
-    assertEquals(uiContext.hotItem, Some(1))
+    assertEquals(uiContext.hotItem, Some(0 -> 1))
     assertEquals(uiContext.activeItem, None)
     assertEquals(uiContext.keyboardFocusItem, None)
 
@@ -30,7 +30,7 @@ class UiContextSpec extends munit.FunSuite:
     assertEquals(itemStatus.hot, true)
     assertEquals(itemStatus.active, true)
     assertEquals(itemStatus.keyboardFocus, true)
-    assertEquals(uiContext.hotItem, Some(1))
+    assertEquals(uiContext.hotItem, Some(0 -> 1))
     assertEquals(uiContext.activeItem, Some(1))
     assertEquals(uiContext.keyboardFocusItem, Some(1))
 
@@ -44,7 +44,7 @@ class UiContextSpec extends munit.FunSuite:
     assertEquals(itemStatus.hot, true)
     assertEquals(itemStatus.active, false)
     assertEquals(itemStatus.keyboardFocus, false)
-    assertEquals(uiContext.hotItem, Some(2))
+    assertEquals(uiContext.hotItem, Some(0 -> 2))
     assertEquals(uiContext.activeItem, Some(1))
     assertEquals(uiContext.keyboardFocusItem, Some(1))
 

--- a/core/src/test/scala/eu/joaocosta/interim/api/LayoutsSpec.scala
+++ b/core/src/test/scala/eu/joaocosta/interim/api/LayoutsSpec.scala
@@ -36,6 +36,14 @@ class LayoutsSpec extends munit.FunSuite:
       )
     assertEquals(areas, expected)
 
+  test("clip correctly does not clip elements with a different z-index"):
+    given uiContext: UiContext   = new UiContext()
+    given inputState: InputState = InputState(0, 0, false, "")
+    Layouts.clip(Rect(10, 10, 10, 10)):
+      Primitives.onTop:
+        Primitives.rectangle(Rect(0, 0, 15, 15), Color(0, 0, 0))
+    assertEquals(uiContext.getOrderedOps(), List(RenderOp.DrawRect(Rect(0, 0, 15, 15), Color(0, 0, 0))))
+
   test("grid returns nothing for an empty grid"):
     val areas    = Layouts.grid(Rect(10, 10, 100, 100), numRows = 0, numColumns = 0, padding = 8)(identity)
     val expected = Vector.empty

--- a/core/src/test/scala/eu/joaocosta/interim/api/LayoutsSpec.scala
+++ b/core/src/test/scala/eu/joaocosta/interim/api/LayoutsSpec.scala
@@ -8,7 +8,7 @@ class LayoutsSpec extends munit.FunSuite:
     given inputState: InputState = InputState(0, 0, false, "")
     Layouts.clip(Rect(10, 10, 10, 10)):
       Primitives.rectangle(Rect(0, 0, 15, 15), Color(0, 0, 0))
-    assertEquals(uiContext.ops.toList, List(RenderOp.DrawRect(Rect(10, 10, 5, 5), Color(0, 0, 0))))
+    assertEquals(uiContext.getOrderedOps(), List(RenderOp.DrawRect(Rect(10, 10, 5, 5), Color(0, 0, 0))))
 
   test("clip ignores input outside the clip area"):
     given uiContext: UiContext   = new UiContext()

--- a/examples/snapshot/5-colorpicker.md
+++ b/examples/snapshot/5-colorpicker.md
@@ -28,6 +28,7 @@ This example contains:
  - Fixed and dynamic layouts, nested
  - Movable and static windows
  - Mutable References
+ - Components with different z-indexes (using `onTop` and `onBottom`)
 
 ![Color picker screenshot](assets/colorpicker.png)
 
@@ -75,54 +76,44 @@ def application(inputState: InputState, appState: AppState) =
   import eu.joaocosta.interim.InterIm.*
 
   ui(inputState, uiContext):
-    appState.asRefs { (colorPickerArea, colorSearchArea, resultDelta, color, query) =>
-      window(id = "color picker", area = colorPickerArea, title = "Color Picker", movable = true) {
-        area =>
-          rows(area = area.shrink(5), numRows = 5, padding = 10) { row =>
+    appState.asRefs: (colorPickerArea, colorSearchArea, resultDelta, color, query) =>
+      onTop:
+        window(id = "color picker", area = colorPickerArea, title = "Color Picker", movable = true): area =>
+          rows(area = area.shrink(5), numRows = 5, padding = 10): row =>
             rectangle(row(0), color.get)
             text(row(1), textColor, color.get.toString, Font.default, alignLeft, centerVertically)
             val r = slider("red slider", row(2), min = 0, max = 255)(color.get.r)
             val g = slider("green slider", row(3), min = 0, max = 255)(color.get.g)
             val b = slider("blue slider", row(4), min = 0, max = 255)(color.get.b)
             color := Color(r, g, b)
-          }
-      }
 
-      window(id = "color search", area = colorSearchArea, title = "Color Search", movable = true) {
-        area =>
-          dynamicRows(area = area.shrink(5), padding = 10) { newRow =>
-            val oldQuery = query.get
-            textInput("query", newRow(16))(query)
-            if (query.get != oldQuery) resultDelta := 0
-            val results = htmlColors.filter(_._1.toLowerCase.startsWith(query.get.toLowerCase))
-            val resultsArea = newRow(maxSize)
-            val buttonSize = 32
-            dynamicColumns(area = resultsArea, padding = 10) { newColumn =>
-              val resultsHeight = results.size * buttonSize
-              if (resultsHeight > resultsArea.h)
-                slider("result scroller", newColumn(-16), min = 0, max = resultsHeight - resultsArea.h)(resultDelta)
-              val clipArea = newColumn(maxSize)
-              clip(area = clipArea) {
-                rows(area = clipArea.copy(y = clipArea.y - resultDelta.get, h = resultsHeight), numRows = results.size, padding = 10) { rows =>
-                  results.zip(rows).foreach { case ((colorName, colorValue), row) =>
-                    if (button(s"$colorName button", row, colorName))
-                      color := colorValue
-                  }
+      window(id = "color search", area = colorSearchArea, title = "Color Search", movable = true): area =>
+        dynamicRows(area = area.shrink(5), padding = 10): newRow =>
+          val oldQuery = query.get
+          textInput("query", newRow(16))(query)
+          if (query.get != oldQuery) resultDelta := 0
+          val results = htmlColors.filter(_._1.toLowerCase.startsWith(query.get.toLowerCase))
+          val resultsArea = newRow(maxSize)
+          val buttonSize = 32
+          dynamicColumns(area = resultsArea, padding = 10): newColumn =>
+            val resultsHeight = results.size * buttonSize
+            if (resultsHeight > resultsArea.h)
+              slider("result scroller", newColumn(-16), min = 0, max = resultsHeight - resultsArea.h)(resultDelta)
+            val clipArea = newColumn(maxSize)
+            clip(area = clipArea):
+              rows(area = clipArea.copy(y = clipArea.y - resultDelta.get, h = resultsHeight), numRows = results.size, padding = 10): rows =>
+                results.zip(rows).foreach { case ((colorName, colorValue), row) =>
+                  if (button(s"$colorName button", row, colorName))
+                    color := colorValue
                 }
-              }
-            }
-          }
-      }
 
-      window(id = "settings", area = Rect(10, 430, 250, 40), title = "Settings", movable = false) { area =>
-        dynamicColumns(area = area.shrink(5), padding = 10) { newColumn =>
-          if (checkbox(id = "dark mode", newColumn(-16))(skins.ColorScheme.darkModeEnabled()))
-            skins.ColorScheme.useDarkMode()
-          else skins.ColorScheme.useLightMode()
-          text(newColumn(maxSize).move(0, 4), textColor, "Dark Mode", Font.default, alignRight)
-        }
-      }
-    }
+      onBottom:
+        window(id = "settings", area = Rect(10, 430, 250, 40), title = "Settings", movable = false): area =>
+          dynamicColumns(area = area.shrink(5), padding = 10): newColumn =>
+            if (checkbox(id = "dark mode", newColumn(-16))(skins.ColorScheme.darkModeEnabled()))
+              skins.ColorScheme.useDarkMode()
+            else skins.ColorScheme.useLightMode()
+            text(newColumn(maxSize).move(0, 4), textColor, "Dark Mode", Font.default, alignRight)
 ```
 
 Let's run it:


### PR DESCRIPTION
Supports components at multiple Z-indices.

This will allow the implementation of things like tooltips and select boxes.

Right now, `clip` will only affect elements in the current z-index. This makes sense for things with a higher z-index (such as tooltips).
I'm not yet sure if elements  with a lower z-index should also be clipped or not, but for now I'll leave it like this.