### PR TITLE
Rename keyboardFocus to selected

### DIFF
--- a/core/src/main/scala/eu/joaocosta/interim/InterIm.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/InterIm.scala
@@ -23,7 +23,7 @@ object InterIm extends api.Primitives with api.Layouts with api.Components with 
     uiContext.ops.clear()
     uiContext.currentZ = 0
     uiContext.hotItem = None
-    if (inputState.mouseDown) uiContext.keyboardFocusItem = None
+    if (inputState.mouseDown) uiContext.selectedItem = None
     // run
     val res = run(using inputState, uiContext)
     // finish

--- a/core/src/main/scala/eu/joaocosta/interim/UiContext.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/UiContext.scala
@@ -55,7 +55,9 @@ object UiContext:
   /** Status of an item.
     *
     *  @param hot if the mouse is on top of the item
-    *  @param active if the mouse clicked the item (and is still pressed down)
+    *  @param active if the mouse clicked the item (and is still pressed down).
+    *                This value stays true for one extra frame, so that it's
+    *                possible to trigger an action on mouse up.
     *  @param selected if this was the last element clicked
     */
   final case class ItemStatus(hot: Boolean, active: Boolean, selected: Boolean)

--- a/core/src/main/scala/eu/joaocosta/interim/UiContext.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/UiContext.scala
@@ -11,9 +11,9 @@ import scala.collection.mutable
   */
 final class UiContext private (
     private[interim] var currentZ: Int,
-    private[interim] var hotItem: Option[(Int, ItemId)],
-    private[interim] var activeItem: Option[ItemId],
-    private[interim] var keyboardFocusItem: Option[ItemId],
+    private[interim] var hotItem: Option[(Int, ItemId)], // Item being hovered by the mouse
+    private[interim] var activeItem: Option[ItemId],     // Item being clicked by the mouse
+    private[interim] var selectedItem: Option[ItemId],   // Last item clicked
     private[interim] val ops: mutable.TreeMap[Int, mutable.Queue[RenderOp]]
 ):
 
@@ -24,8 +24,8 @@ final class UiContext private (
       hotItem = Some(currentZ -> id)
       if (!passive && (activeItem == None || activeItem == Some(id)) && inputState.mouseDown)
         activeItem = Some(id)
-        keyboardFocusItem = Some(id)
-    UiContext.ItemStatus(hotItem.map(_._2) == Some(id), activeItem == Some(id), keyboardFocusItem == Some(id))
+        selectedItem = Some(id)
+    UiContext.ItemStatus(hotItem.map(_._2) == Some(id), activeItem == Some(id), selectedItem == Some(id))
 
   private[interim] def getOrderedOps(): List[RenderOp] =
     ops.values.toList.flatten
@@ -33,14 +33,14 @@ final class UiContext private (
   def this() = this(0, None, None, None, new mutable.TreeMap())
 
   override def clone(): UiContext =
-    new UiContext(currentZ, hotItem, activeItem, keyboardFocusItem, ops.clone().mapValuesInPlace((_, v) => v.clone()))
+    new UiContext(currentZ, hotItem, activeItem, selectedItem, ops.clone().mapValuesInPlace((_, v) => v.clone()))
 
-  def fork(): UiContext = new UiContext(currentZ, hotItem, activeItem, keyboardFocusItem, new mutable.TreeMap())
+  def fork(): UiContext = new UiContext(currentZ, hotItem, activeItem, selectedItem, new mutable.TreeMap())
 
   def ++=(that: UiContext): this.type =
     this.hotItem = that.hotItem
     this.activeItem = that.activeItem
-    this.keyboardFocusItem = that.keyboardFocusItem
+    this.selectedItem = that.selectedItem
     that.ops.foreach: (z, ops) =>
       if (this.ops.contains(z)) this.ops(z) ++= that.ops(z)
       else this.ops(z) = that.ops(z)
@@ -56,9 +56,9 @@ object UiContext:
     *
     *  @param hot if the mouse is on top of the item
     *  @param active if the mouse clicked the item (and is still pressed down)
-    *  @param keyboardFocus if the keyboard events should be consumed by this item
+    *  @param selected if this was the last element clicked
     */
-  final case class ItemStatus(hot: Boolean, active: Boolean, keyboardFocus: Boolean)
+  final case class ItemStatus(hot: Boolean, active: Boolean, selected: Boolean)
 
   /** Registers an item on the UI state, taking a certain area.
     *

--- a/core/src/main/scala/eu/joaocosta/interim/api/Components.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Components.scala
@@ -91,11 +91,11 @@ trait Components:
         val selectBoxArea = skin.selectBoxArea(area)
         val itemStatus    = UiContext.registerItem(id, area)
         val selectedValue = value.get.merge
-        if (itemStatus.keyboardFocus) value := Left(selectedValue)
+        if (itemStatus.selected) value := Left(selectedValue)
         val isOpen = value.get.isLeft
         skin.renderSelectBox(area, selectedValue, labels, itemStatus)
         if (isOpen)
-          if (!itemStatus.keyboardFocus) value := Right(selectedValue)
+          if (!itemStatus.selected) value := Right(selectedValue)
           labels.zipWithIndex.foreach: (label, idx) =>
             val selectOptionArea = skin.selectOptionArea(area, idx)
             val optionStatus     = UiContext.registerItem(id |> idx, selectOptionArea)
@@ -146,7 +146,7 @@ trait Components:
         val textInputArea = skin.textInputArea(area)
         val itemStatus    = UiContext.registerItem(id, textInputArea)
         skin.renderTextInput(area, value.get, itemStatus)
-        if (itemStatus.keyboardFocus)
+        if (itemStatus.selected)
           value.modify(summon[InputState].appendKeyboardInput)
         value.get
 

--- a/core/src/test/scala/eu/joaocosta/interim/UiContextSpec.scala
+++ b/core/src/test/scala/eu/joaocosta/interim/UiContextSpec.scala
@@ -7,10 +7,10 @@ class UiContextSpec extends munit.FunSuite:
     val itemStatus               = UiContext.registerItem(1, Rect(1, 1, 10, 10))
     assertEquals(itemStatus.hot, false)
     assertEquals(itemStatus.active, false)
-    assertEquals(itemStatus.keyboardFocus, false)
+    assertEquals(itemStatus.selected, false)
     assertEquals(uiContext.hotItem, None)
     assertEquals(uiContext.activeItem, None)
-    assertEquals(uiContext.keyboardFocusItem, None)
+    assertEquals(uiContext.selectedItem, None)
 
   test("registerItem should mark an item under the cursor as hot"):
     given uiContext: UiContext   = new UiContext()
@@ -18,10 +18,10 @@ class UiContextSpec extends munit.FunSuite:
     val itemStatus               = UiContext.registerItem(1, Rect(1, 1, 10, 10))
     assertEquals(itemStatus.hot, true)
     assertEquals(itemStatus.active, false)
-    assertEquals(itemStatus.keyboardFocus, false)
+    assertEquals(itemStatus.selected, false)
     assertEquals(uiContext.hotItem, Some(0 -> 1))
     assertEquals(uiContext.activeItem, None)
-    assertEquals(uiContext.keyboardFocusItem, None)
+    assertEquals(uiContext.selectedItem, None)
 
   test("registerItem should mark a clicked item as active and focused"):
     given uiContext: UiContext   = new UiContext()
@@ -29,10 +29,10 @@ class UiContextSpec extends munit.FunSuite:
     val itemStatus               = UiContext.registerItem(1, Rect(1, 1, 10, 10))
     assertEquals(itemStatus.hot, true)
     assertEquals(itemStatus.active, true)
-    assertEquals(itemStatus.keyboardFocus, true)
+    assertEquals(itemStatus.selected, true)
     assertEquals(uiContext.hotItem, Some(0 -> 1))
     assertEquals(uiContext.activeItem, Some(1))
-    assertEquals(uiContext.keyboardFocusItem, Some(1))
+    assertEquals(uiContext.selectedItem, Some(1))
 
   test("registerItem should not override an active item with another one"):
     val uiContext   = new UiContext()
@@ -43,10 +43,10 @@ class UiContextSpec extends munit.FunSuite:
     val itemStatus = UiContext.registerItem(2, Rect(15, 15, 10, 10))(using uiContext, inputState2)
     assertEquals(itemStatus.hot, true)
     assertEquals(itemStatus.active, false)
-    assertEquals(itemStatus.keyboardFocus, false)
+    assertEquals(itemStatus.selected, false)
     assertEquals(uiContext.hotItem, Some(0 -> 2))
     assertEquals(uiContext.activeItem, Some(1))
-    assertEquals(uiContext.keyboardFocusItem, Some(1))
+    assertEquals(uiContext.selectedItem, Some(1))
 
   test("fork should create a new UiContext with no ops, and merge them back with ++="):
     val uiContext: UiContext = new UiContext()


### PR DESCRIPTION
The previous name was a bit confusing, as this is not always related to the keyboard.