### PR TITLE
Code cleanup

### DIFF
--- a/core/src/main/scala/eu/joaocosta/interim/InputState.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/InputState.scala
@@ -12,6 +12,7 @@ import scala.annotation.tailrec
   *   A `\u0008` character is interpreted as a backspace.
   */
 final case class InputState(mouseX: Int, mouseY: Int, mouseDown: Boolean, keyboardInput: String):
+
   /** Appends the current keyboard input to an already existing string.
     * A `\u0008` character in the input is interpreted as a backspace.
     */

--- a/core/src/main/scala/eu/joaocosta/interim/InterIm.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/InterIm.scala
@@ -9,6 +9,7 @@ import eu.joaocosta.interim.TextLayout.*
   * import the DSL and explicitly use the InterIm prefix (e.g. `IterIm.text` instead of `text`)
   */
 object InterIm extends api.Primitives with api.Layouts with api.Components with api.Constants with api.Panels:
+
   /** Wraps the UI interactions. All API calls should happen inside the body (run parameter).
     *
     * This method takes an input state and a UI context and mutates the UI context accordingly.

--- a/core/src/main/scala/eu/joaocosta/interim/ItemId.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/ItemId.scala
@@ -8,20 +8,19 @@ import scala.annotation.targetName
   */
 type ItemId = (Int | String) | List[(Int | String)]
 
-object ItemId:
-  /** Helper method to convert an ItemId into a List
-    */
-  extension (itemId: ItemId)
-    def toIdList: List[(Int | String)] =
-      itemId match {
-        case int: Int                   => List(int)
-        case str: String                => List(str)
-        case list: List[(Int | String)] => list
-      }
+/** Helper method to convert an ItemId into a List
+  */
+extension (itemId: ItemId)
+  def toIdList: List[(Int | String)] =
+    itemId match {
+      case int: Int                   => List(int)
+      case str: String                => List(str)
+      case list: List[(Int | String)] => list
+    }
 
-  /** Operator to add a child to an item id. Useful for composite components.
-    */
-  extension (parentId: ItemId)
-    @targetName("addChild")
-    def |>(childId: ItemId): ItemId =
-      parentId.toIdList ++ childId.toIdList
+/** Operator to add a child to an item id. Useful for composite components.
+  */
+extension (parentId: ItemId)
+  @targetName("addChild")
+  def |>(childId: ItemId): ItemId =
+    parentId.toIdList ++ childId.toIdList

--- a/core/src/main/scala/eu/joaocosta/interim/Rect.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/Rect.scala
@@ -1,6 +1,6 @@
 package eu.joaocosta.interim
 
-import scala.annotation.alpha
+import scala.annotation.targetName
 
 /** Rectangle abstraction, which represents an area with positive width and height.
   *
@@ -47,7 +47,7 @@ final case class Rect(x: Int, y: Int, w: Int, h: Int):
     *
     * Gaps between the rectangles will also be considered as part of the final area.
     */
-  @alpha("merge")
+  @targetName("merge")
   def ++(that: Rect): Rect =
     val minX = math.min(this.x1, that.x1)
     val maxX = math.max(this.x2, that.x2)
@@ -57,7 +57,7 @@ final case class Rect(x: Int, y: Int, w: Int, h: Int):
 
   /** Intersects this rectangle with another one.
     */
-  @alpha("intersect")
+  @targetName("intersect")
   def &(that: Rect): Rect =
     val maxX1 = math.max(this.x1, that.x1)
     val maxY1 = math.max(this.y1, that.y1)

--- a/core/src/main/scala/eu/joaocosta/interim/Ref.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/Ref.scala
@@ -1,4 +1,4 @@
-package eu.joaocosta.interim.api
+package eu.joaocosta.interim
 
 import scala.annotation.targetName
 import scala.deriving.Mirror
@@ -53,16 +53,16 @@ object Ref:
       refTuple.map([T] => (x: T) => x.asInstanceOf[Ref[_]].value.asInstanceOf[UnRef[T]]).asInstanceOf
     mirror.fromTuple(updatedTuple)
 
-  /** Wraps this value into a Ref and passes it to a block, returning the final value of the ref.
-    *
-    * Useful to set temporary mutable variables.
-    */
-  extension [T](x: T) def asRef(block: Ref[T] => Unit): T = withRef(x)(block)
+/** Wraps this value into a Ref and passes it to a block, returning the final value of the ref.
+  *
+  * Useful to set temporary mutable variables.
+  */
+extension [T](x: T) def asRef(block: Ref[T] => Unit): T = Ref.withRef(x)(block)
 
-  /** Destructures this value into multiple Refs and passes it to a block, returning the final value of the ref.
-    *
-    * Useful to set temporary mutable variables.
-    */
-  extension [T <: Product](x: T)
-    def asRefs(using mirror: Mirror.ProductOf[T])(block: Tuple.Map[mirror.MirroredElemTypes, Ref] => Unit): T =
-      withRefs(x)(block)
+/** Destructures this value into multiple Refs and passes it to a block, returning the final value of the ref.
+  *
+  * Useful to set temporary mutable variables.
+  */
+extension [T <: Product](x: T)
+  def asRefs(using mirror: Mirror.ProductOf[T])(block: Tuple.Map[mirror.MirroredElemTypes, Ref] => Unit): T =
+    Ref.withRefs(x)(block)

--- a/core/src/main/scala/eu/joaocosta/interim/RenderOp.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/RenderOp.scala
@@ -21,6 +21,7 @@ sealed trait RenderOp {
 }
 
 object RenderOp:
+
   /** Operation to draw a rectangle on the screen.
     *
     *  @param area area to render

--- a/core/src/main/scala/eu/joaocosta/interim/TextLayout.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/TextLayout.scala
@@ -3,6 +3,7 @@ package eu.joaocosta.interim
 import scala.annotation.tailrec
 
 object TextLayout:
+
   enum HorizontalAlignment:
     case Left, Center, Right
 
@@ -88,5 +89,4 @@ object TextLayout:
             if (ops.isEmpty && nextLine == remaining) layout("", dy, textAcc) // Can't fit a single character, end here
             else
               layout(nextLine, dy + lineHeight, alignH(ops, textOp.textArea.w, textOp.horizontalAlignment) ++ textAcc)
-
     layout(textOp.text, 0, Nil).filter(char => (char.area & textOp.area) == char.area)

--- a/core/src/main/scala/eu/joaocosta/interim/api/Components.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Components.scala
@@ -46,9 +46,8 @@ trait Components:
         val checkboxArea = skin.checkboxArea(area)
         val itemStatus   = UiContext.registerItem(id, checkboxArea)
         skin.renderCheckbox(area, value.get, itemStatus)
-        if (itemStatus.hot && itemStatus.active && summon[InputState].mouseDown == false)
-          value.modify(!_).get
-        else value.get
+        if (itemStatus.hot && itemStatus.active && summon[InputState].mouseDown == false) value.modify(!_)
+        value.get
 
   /** Radio button component. Returns value currently selected.
     *
@@ -69,7 +68,7 @@ trait Components:
         if (itemStatus.hot && itemStatus.active && summon[InputState].mouseDown == false)
           value := buttonValue
         if (value.get == buttonValue) skin.renderButton(area, label, itemStatus.copy(hot = true, active = true))
-        else (skin.renderButton(area, label, itemStatus))
+        else skin.renderButton(area, label, itemStatus)
         value.get
 
   /** Select box component. Returns the index value currently selected inside a PanelState.

--- a/core/src/main/scala/eu/joaocosta/interim/api/Components.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Components.scala
@@ -1,6 +1,5 @@
 package eu.joaocosta.interim.api
 
-import eu.joaocosta.interim.ItemId.*
 import eu.joaocosta.interim.*
 import eu.joaocosta.interim.skins.*
 

--- a/core/src/main/scala/eu/joaocosta/interim/api/Components.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Components.scala
@@ -13,14 +13,15 @@ trait Components:
 
   type Component[+T] = (inputState: InputState, uiContext: UiContext) ?=> T
 
-  trait ComponentWithValue[T] {
+  trait ComponentWithValue[T]:
     def applyRef(value: Ref[T]): Component[T]
+
     def applyValue(value: T): Component[T] =
       apply(Ref(value))
+
     inline def apply(value: T | Ref[T]): Component[T] = inline value match
       case x: T      => applyValue(x)
       case x: Ref[T] => applyRef(x)
-  }
 
   /** Button component. Returns true if it's being clicked, false otherwise.
     *

--- a/core/src/main/scala/eu/joaocosta/interim/api/Panels.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Panels.scala
@@ -8,7 +8,7 @@ import eu.joaocosta.interim.skins.*
   *
   * Panels are a mix of a component and a layout. They perform rendering operations, but also provide a draw area.
   *
-  * By convention, all panels are of the form `def panel(id, area, params..., skin)(body): (Value, Rect)`.
+  * By convention, all panels are of the form `def panel(id, area, params..., skin)(body): (Option[Value], PanelState[Rect])`.
   * The returned value is the value returned by the body. Panels also return a rect, which is the area
   * the panel must be called with in the next frame (e.g. for movable panels).
   *

--- a/core/src/main/scala/eu/joaocosta/interim/api/Panels.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Panels.scala
@@ -40,11 +40,10 @@ trait Panels:
   )(
       body: Rect => T
   ): Components.Component[(Option[T], PanelState[Rect])] =
-    val panelStateRef = area match {
+    val panelStateRef = area match
       case ref: Ref[PanelState[Rect]] => ref
       case v: PanelState[Rect]        => Ref(v)
       case v: Rect                    => Ref(PanelState.open(v))
-    }
     if (panelStateRef.get.isOpen)
       val windowArea = panelStateRef.get.value
       UiContext.registerItem(id, windowArea, passive = true)

--- a/core/src/main/scala/eu/joaocosta/interim/api/Panels.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Panels.scala
@@ -1,6 +1,6 @@
 package eu.joaocosta.interim.api
 
-import eu.joaocosta.interim.ItemId.*
+//import eu.joaocosta.interim.ItemId.*
 import eu.joaocosta.interim.*
 import eu.joaocosta.interim.skins.*
 

--- a/core/src/main/scala/eu/joaocosta/interim/api/Primitives.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Primitives.scala
@@ -10,6 +10,7 @@ import eu.joaocosta.interim.{Color, Font, Rect, RenderOp, UiContext}
 object Primitives extends Primitives
 
 trait Primitives:
+
   /** Draws a rectangle filling a the specified area with a color.
     */
   final def rectangle(area: Rect, color: Color)(using uiContext: UiContext): Unit =

--- a/core/src/main/scala/eu/joaocosta/interim/skins/ButtonSkin.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/skins/ButtonSkin.scala
@@ -11,6 +11,7 @@ trait ButtonSkin:
   ): Unit
 
 object ButtonSkin extends DefaultSkin:
+
   final case class Default(
       shadowDelta: Int,
       clickDelta: Int,
@@ -21,8 +22,10 @@ object ButtonSkin extends DefaultSkin:
       hotColor: Color,
       activeColor: Color
   ) extends ButtonSkin:
+
     def buttonArea(area: Rect): Rect =
       area.copy(w = area.w - math.max(shadowDelta, clickDelta), h = area.h - math.max(shadowDelta, clickDelta))
+
     def renderButton(area: Rect, label: String, itemStatus: UiContext.ItemStatus)(using
         uiContext: UiContext
     ): Unit =

--- a/core/src/main/scala/eu/joaocosta/interim/skins/CheckboxSkin.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/skins/CheckboxSkin.scala
@@ -8,6 +8,7 @@ trait CheckboxSkin:
   def renderCheckbox(area: Rect, value: Boolean, itemStatus: UiContext.ItemStatus)(using uiContext: UiContext): Unit
 
 object CheckboxSkin extends DefaultSkin:
+
   final case class Default(
       padding: Int,
       inactiveColor: Color,
@@ -15,9 +16,11 @@ object CheckboxSkin extends DefaultSkin:
       activeColor: Color,
       checkColor: Color
   ) extends CheckboxSkin:
+
     def checkboxArea(area: Rect): Rect =
       val smallSide = math.min(area.w, area.h)
       area.copy(w = smallSide, h = smallSide)
+
     def renderCheckbox(area: Rect, value: Boolean, itemStatus: UiContext.ItemStatus)(using uiContext: UiContext): Unit =
       val checkboxArea = this.checkboxArea(area)
       itemStatus match

--- a/core/src/main/scala/eu/joaocosta/interim/skins/HandleSkin.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/skins/HandleSkin.scala
@@ -6,15 +6,18 @@ import eu.joaocosta.interim.api.Primitives.*
 trait HandleSkin:
   def moveHandleArea(area: Rect): Rect
   def closeHandleArea(area: Rect): Rect
+
   def renderMoveHandle(area: Rect, value: Rect, itemStatus: UiContext.ItemStatus)(using uiContext: UiContext): Unit
   def renderCloseHandle(area: Rect, itemStatus: UiContext.ItemStatus)(using uiContext: UiContext): Unit
 
 object HandleSkin extends DefaultSkin:
+
   final case class Default(
       inactiveColor: Color,
       hotColor: Color,
       activeColor: Color
   ) extends HandleSkin:
+
     def moveHandleArea(area: Rect): Rect =
       val smallSide = math.min(area.w, area.h)
       area.copy(w = smallSide, h = smallSide)

--- a/core/src/main/scala/eu/joaocosta/interim/skins/SelectSkin.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/skins/SelectSkin.scala
@@ -8,12 +8,14 @@ trait SelectSkin:
   def renderSelectBox(area: Rect, value: Int, labels: Vector[String], itemStatus: UiContext.ItemStatus)(using
       uiContext: UiContext
   ): Unit
+
   def selectOptionArea(area: Rect, value: Int): Rect
   def renderSelectOption(area: Rect, value: Int, labels: Vector[String], itemStatus: UiContext.ItemStatus)(using
       uiContext: UiContext
   ): Unit
 
 object SelectSkin extends DefaultSkin:
+
   final case class Default(
       border: Int,
       font: Font,
@@ -22,9 +24,11 @@ object SelectSkin extends DefaultSkin:
       activeColor: Color,
       textColor: Color
   ) extends SelectSkin:
+
     // Select box
     def selectBoxArea(area: Rect): Rect =
       area
+
     def renderSelectBox(area: Rect, value: Int, labels: Vector[String], itemStatus: UiContext.ItemStatus)(using
         uiContext: UiContext
     ): Unit =
@@ -45,9 +49,11 @@ object SelectSkin extends DefaultSkin:
         TextLayout.HorizontalAlignment.Left,
         TextLayout.VerticalAlignment.Center
       )
+
     // Select option
     def selectOptionArea(area: Rect, value: Int): Rect =
       area.copy(y = area.y + area.h * (value + 1))
+
     def renderSelectOption(area: Rect, value: Int, labels: Vector[String], itemStatus: UiContext.ItemStatus)(using
         uiContext: UiContext
     ): Unit =

--- a/core/src/main/scala/eu/joaocosta/interim/skins/SliderSkin.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/skins/SliderSkin.scala
@@ -11,6 +11,7 @@ trait SliderSkin:
   ): Unit
 
 object SliderSkin extends DefaultSkin:
+
   final case class Default(
       padding: Int,
       minSliderSize: Int,
@@ -19,12 +20,14 @@ object SliderSkin extends DefaultSkin:
       hotColor: Color,
       activeColor: Color
   ) extends SliderSkin:
+
     def sliderSize(area: Rect, min: Int, max: Int): Int =
       val steps = (max - min) + 1
       math.max(minSliderSize, math.max(area.w, area.h) / steps)
 
     def sliderArea(area: Rect): Rect =
       Rect(area.x + padding, area.y + padding, area.w - 2 * padding, area.h - 2 * padding)
+
     def renderSlider(area: Rect, min: Int, value: Int, max: Int, itemStatus: UiContext.ItemStatus)(using
         uiContext: UiContext
     ): Unit =

--- a/core/src/main/scala/eu/joaocosta/interim/skins/TextInputSkin.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/skins/TextInputSkin.scala
@@ -8,6 +8,7 @@ trait TextInputSkin:
   def renderTextInput(area: Rect, value: String, itemStatus: UiContext.ItemStatus)(using uiContext: UiContext): Unit
 
 object TextInputSkin extends DefaultSkin:
+
   final case class Default(
       border: Int,
       font: Font,
@@ -17,8 +18,10 @@ object TextInputSkin extends DefaultSkin:
       textAreaColor: Color,
       textColor: Color
   ) extends TextInputSkin:
+
     def textInputArea(area: Rect): Rect =
       area.shrink(border)
+
     def renderTextInput(area: Rect, value: String, itemStatus: UiContext.ItemStatus)(using uiContext: UiContext): Unit =
       val textInputArea = this.textInputArea(area)
       itemStatus match

--- a/core/src/main/scala/eu/joaocosta/interim/skins/WindowSkin.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/skins/WindowSkin.scala
@@ -12,18 +12,23 @@ trait WindowSkin:
   def renderWindow(area: Rect, title: String)(using uiContext: UiContext): Unit
 
 object WindowSkin extends DefaultSkin:
+
   final case class Default(
       font: Font,
       textColor: Color,
       panelColor: Color,
       titleColor: Color
   ) extends WindowSkin:
+
     def titleArea(area: Rect): Rect =
       area.copy(h = font.fontSize * 2)
+
     def titleTextArea(area: Rect): Rect =
       area.copy(h = font.fontSize * 2).shrink(font.fontSize / 2)
+
     def panelArea(area: Rect): Rect =
       area.copy(y = area.y + font.fontSize * 2, h = area.h - font.fontSize * 2)
+
     def renderWindow(area: Rect, title: String)(using uiContext: UiContext): Unit =
       val titleArea = this.titleArea(area)
       val panelArea = this.panelArea(area)

--- a/core/src/test/scala/eu/joaocosta/interim/InputStateSpec.scala
+++ b/core/src/test/scala/eu/joaocosta/interim/InputStateSpec.scala
@@ -3,6 +3,7 @@ package eu.joaocosta.interim
 import scala.annotation.tailrec
 
 class InputStateSpec extends munit.FunSuite:
+
   test("appendKeyboardInput should preserve the original string"):
     val result = InputState(0, 0, false, "").appendKeyboardInput("test")
     assertEquals(result, "test")

--- a/core/src/test/scala/eu/joaocosta/interim/RectSpec.scala
+++ b/core/src/test/scala/eu/joaocosta/interim/RectSpec.scala
@@ -1,6 +1,7 @@
 package eu.joaocosta.interim
 
 class RectSpec extends munit.FunSuite:
+
   test("isMouseOver detects collisions with the mouse"):
     val rect = Rect(10, 10, 10, 10)
     assertEquals(rect.isMouseOver(using InputState(0, 0, false, "")), false)

--- a/core/src/test/scala/eu/joaocosta/interim/RefSpec.scala
+++ b/core/src/test/scala/eu/joaocosta/interim/RefSpec.scala
@@ -1,4 +1,4 @@
-package eu.joaocosta.interim.api
+package eu.joaocosta.interim
 
 class RefSpec extends munit.FunSuite:
   test("A Ref value can be correctly set and retrieved with := and get"):
@@ -30,14 +30,12 @@ class RefSpec extends munit.FunSuite:
   }
 
   test("asRef allows to use a temporary Ref value"):
-    import Ref.asRef
     val result = 0.asRef { ref =>
       ref.modify(_ + 2)
     }
     assertEquals(result, 2)
 
   test("asRefs allows to build a case class from temporary Ref value"):
-    import Ref.asRefs
     case class Foo(x: Int, y: String)
     val result = Foo(1, "asd").asRefs { (x, y) =>
       x := 2

--- a/core/src/test/scala/eu/joaocosta/interim/RefSpec.scala
+++ b/core/src/test/scala/eu/joaocosta/interim/RefSpec.scala
@@ -1,6 +1,7 @@
 package eu.joaocosta.interim
 
 class RefSpec extends munit.FunSuite:
+
   test("A Ref value can be correctly set and retrieved with := and get"):
     val x = Ref(1)
     assertEquals(x.get, 1)
@@ -14,31 +15,25 @@ class RefSpec extends munit.FunSuite:
     assertEquals(x.get, 2)
 
   test("withRef allows to use a temporary Ref value"):
-    val result = Ref.withRef(0) { ref =>
+    val result = Ref.withRef(0): ref =>
       ref.modify(_ + 2)
-    }
     assertEquals(result, 2)
 
-  // Braces needed due to https://github.com/scalameta/scalafmt/issues/3597
-  test("withRefs allows to build a case class from temporary Ref value") {
+  test("withRefs allows to build a case class from temporary Ref value"):
     case class Foo(x: Int, y: String)
-    val result = Ref.withRefs(Foo(1, "asd")) { (x, y) =>
+    val result = Ref.withRefs(Foo(1, "asd")): (x, y) =>
       x := 2
       y := "dsa"
-    }
     assertEquals(result, Foo(2, "dsa"))
-  }
 
   test("asRef allows to use a temporary Ref value"):
-    val result = 0.asRef { ref =>
+    val result = 0.asRef: ref =>
       ref.modify(_ + 2)
-    }
     assertEquals(result, 2)
 
   test("asRefs allows to build a case class from temporary Ref value"):
     case class Foo(x: Int, y: String)
-    val result = Foo(1, "asd").asRefs { (x, y) =>
+    val result = Foo(1, "asd").asRefs: (x, y) =>
       x := 2
       y := "dsa"
-    }
     assertEquals(result, Foo(2, "dsa"))

--- a/core/src/test/scala/eu/joaocosta/interim/UiContextSpec.scala
+++ b/core/src/test/scala/eu/joaocosta/interim/UiContextSpec.scala
@@ -1,6 +1,7 @@
 package eu.joaocosta.interim
 
 class UiContextSpec extends munit.FunSuite:
+
   test("registerItem should not mark an item not under the cursor"):
     given uiContext: UiContext   = new UiContext()
     given inputState: InputState = InputState(0, 0, false, "")

--- a/core/src/test/scala/eu/joaocosta/interim/api/LayoutsSpec.scala
+++ b/core/src/test/scala/eu/joaocosta/interim/api/LayoutsSpec.scala
@@ -3,6 +3,7 @@ package eu.joaocosta.interim.api
 import eu.joaocosta.interim.{Color, InputState, Rect, RenderOp, UiContext}
 
 class LayoutsSpec extends munit.FunSuite:
+
   test("clip correctly clips render ops"):
     given uiContext: UiContext   = new UiContext()
     given inputState: InputState = InputState(0, 0, false, "")

--- a/examples/snapshot/1-intro.md
+++ b/examples/snapshot/1-intro.md
@@ -52,7 +52,7 @@ Now, let's write our interface. We are going to need the following components:
 
 ```scala
 def application(inputState: InputState) =
-  import eu.joaocosta.interim.InterIm._
+  import eu.joaocosta.interim.InterIm.*
   ui(inputState, uiContext):
     if (button(id = "minus", area = Rect(x = 10, y = 10, w = 30, h = 30), label = "-"))
       counter = counter - 1
@@ -73,7 +73,7 @@ Let's go line by line:
 First, our application will need to somehow receive input (e.g. mouse clicks), so we need to provide the `InputState`
 from our backend.
 
-Then, we import `import eu.joaocosta.interim.InterIm._`. This enables the InterIm DSL, which give us access to our
+Then, we import `import eu.joaocosta.interim.InterIm.*`. This enables the InterIm DSL, which give us access to our
 component functions.
 
 Next, we start our UI with `ui(inputState, uiContext)`. All DSL operation must happen inside this block which,
@@ -125,7 +125,7 @@ For example we could rewrite our application as:
 
 ```scala
 def immutableApp(inputState: InputState, counter: Int): (List[RenderOp], Int) =
-  import eu.joaocosta.interim.InterIm._
+  import eu.joaocosta.interim.InterIm.*
   ui(inputState, uiContext):
     val (decrementCounter, _, incrementCounter) = (
       button(id = "minus", area = Rect(x = 10, y = 10, w = 30, h = 30), label = "-"),
@@ -151,7 +151,7 @@ One possible solution to this is to use local mutability:
 
 ```scala
 def localMutableApp(inputState: InputState, counter: Int): (List[RenderOp], Int) =
-  import eu.joaocosta.interim.InterIm._
+  import eu.joaocosta.interim.InterIm.*
   var _counter = counter
   ui(inputState, uiContext):
     if (button(id = "minus", area = Rect(x = 10, y = 10, w = 30, h = 30), label = "-"))

--- a/examples/snapshot/2-layout.md
+++ b/examples/snapshot/2-layout.md
@@ -48,7 +48,7 @@ val uiContext = new UiContext()
 var counter = 0
 
 def application(inputState: InputState) =
-  import eu.joaocosta.interim.InterIm._
+  import eu.joaocosta.interim.InterIm.*
   ui(inputState, uiContext):
     columns(area = Rect(x = 10, y = 10, w = 110, h = 30), numColumns = 3, padding = 10) { column =>
       if (button(id = "minus", area = column(0), label = "-"))
@@ -85,7 +85,7 @@ For example, this is how our application would look like with a dynamic layout:
 
 ```scala
 def dynamicApp(inputState: InputState) =
-  import eu.joaocosta.interim.InterIm._
+  import eu.joaocosta.interim.InterIm.*
   ui(inputState, uiContext):
     dynamicColumns(area = Rect(x = 10, y = 10, w = 110, h = 30), padding = 10) { column =>
       if (button(id = "minus", area = column(30), label = "-")) // 30px from the left

--- a/examples/snapshot/3-windows.md
+++ b/examples/snapshot/3-windows.md
@@ -38,7 +38,7 @@ var windowArea = PanelState.open(Rect(x = 10, y = 10, w = 110, h = 50))
 var counter    = 0
 
 def application(inputState: InputState) =
-  import eu.joaocosta.interim.InterIm._
+  import eu.joaocosta.interim.InterIm.*
   ui(inputState, uiContext):
     windowArea = window(id = "window", area = windowArea, title = "My Counter", movable = true, closable = false) { area =>
       columns(area = area.shrink(5), numColumns = 3, padding = 10) { column =>

--- a/examples/snapshot/4-refs.md
+++ b/examples/snapshot/4-refs.md
@@ -29,7 +29,6 @@ The example above could also be written as:
 
 ```scala
 import eu.joaocosta.interim.*
-import eu.joaocosta.interim.api.Ref
 
 val uiContext = new UiContext()
 
@@ -37,7 +36,7 @@ val windowArea = Ref(PanelState.open(Rect(x = 10, y = 10, w = 110, h = 50))) // 
 var counter    = 0
 
 def application(inputState: InputState) =
-  import eu.joaocosta.interim.InterIm._
+  import eu.joaocosta.interim.InterIm.*
   ui(inputState, uiContext):
     // window takes area as a ref, so will mutate the window area variable
     window(id = "window", area = windowArea, title = "My Counter", movable = true) { area =>
@@ -74,7 +73,6 @@ of `Ref`s that can be used inside the block. At the end of the block, a new obje
 
 ```scala reset
 import eu.joaocosta.interim.*
-import eu.joaocosta.interim.api.Ref
 
 val uiContext = new UiContext()
 
@@ -82,8 +80,7 @@ case class AppState(counter: Int = 0, windowArea: PanelState[Rect] = PanelState.
 val initialState = AppState()
 
 def applicationRef(inputState: InputState, appState: AppState) =
-  import eu.joaocosta.interim.InterIm._
-  import eu.joaocosta.interim.api.Ref.asRefs
+  import eu.joaocosta.interim.InterIm.*
   ui(inputState, uiContext):
     appState.asRefs { (counter, windowArea) =>
       window(id = "window", area = windowArea, title = "My Counter", movable = true) { area =>

--- a/examples/snapshot/5-colorpicker.md
+++ b/examples/snapshot/5-colorpicker.md
@@ -36,7 +36,6 @@ This one is more of a show off of what you can do.
 
 ```scala
 import eu.joaocosta.interim.*
-import eu.joaocosta.interim.api.Ref.asRefs
 
 val uiContext = new UiContext()
 


### PR DESCRIPTION
General code cleanup
Also moves the extension methods away from the objects and into the `interim` package, so they are easier to import.