### PR TITLE
Add a Font constructor with constant width

### DIFF
--- a/core/src/main/scala/eu/joaocosta/interim/Font.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/Font.scala
@@ -17,5 +17,14 @@ object Font:
     */
   def apply(name: String, fontSize: Int): Font = Font(name, fontSize, _ => fontSize)
 
+  /** A description of a font.
+    *
+    * All chars are assumed to have the same width.
+    * @param name font name
+    * @param fontSize font height in pixels
+    * @param charWidth character width in pixels
+    */
+  def apply(name: String, fontSize: Int, charWidth: Int): Font = Font(name, fontSize, _ => charWidth)
+
   /** The default font */
   val default = Font("default", 8)


### PR DESCRIPTION
Most bitmap fonts have a constant width (even if the width doesn't match the height), so this is quite handy.