### PR TITLE
Track historical input states for a better dragging experience

### DIFF
--- a/core/src/main/scala/eu/joaocosta/interim/InputState.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/InputState.scala
@@ -2,16 +2,22 @@ package eu.joaocosta.interim
 
 import scala.annotation.tailrec
 
-/** Input State to be used by the components.
-  *
-  * @param mouseX mouse X position, from the left
-  * @param mouseY mouse Y position, from the top
-  * @param mouseDown whether the body is pressed
-  * @param keyboardInput
-  *   String generated from the keyboard inputs since the last frame. Usually this will be a single character.
-  *   A `\u0008` character is interpreted as a backspace.
-  */
-final case class InputState(mouseX: Int, mouseY: Int, mouseDown: Boolean, keyboardInput: String):
+/** Input State to be used by the components. */
+sealed trait InputState:
+
+  /** Mouse X position, from the left */
+  def mouseX: Int
+
+  /** Mouse Y position, from the top */
+  def mouseY: Int
+
+  /** @param mouseDown whether the mouse is pressed */
+  def mouseDown: Boolean
+
+  /** String generated from the keyboard inputs since the last frame. Usually this will be a single character.
+    * A `\u0008` character is interpreted as a backspace.
+    */
+  def keyboardInput: String
 
   /** Appends the current keyboard input to an already existing string.
     * A `\u0008` character in the input is interpreted as a backspace.
@@ -34,3 +40,68 @@ final case class InputState(mouseX: Int, mouseY: Int, mouseDown: Boolean, keyboa
       processedString
         .filterNot(Character.isISOControl)
         .mkString
+
+  /** Clips the mouse position to a rectagle. If the mouse is outside of the region, it will be moved to (Int.MinValue, Int.MinValue) */
+  def clip(area: Rect): InputState
+
+object InputState:
+  /** Creates a new Input State
+    *
+    * @param mouseX mouse X position, from the left
+    * @param mouseY mouse Y position, from the top
+    * @param mouseDown whether the body is pressed
+    * @param keyboardInput
+    *   String generated from the keyboard inputs since the last frame. Usually this will be a single character.
+    *   A `\u0008` character is interpreted as a backspace.
+    */
+  def apply(mouseX: Int, mouseY: Int, mouseDown: Boolean, keyboardInput: String): InputState =
+    InputState.Current(mouseX, mouseY, mouseDown, keyboardInput: String)
+
+  /** Input state at the current point in time
+    *
+    * @param mouseX mouse X position, from the left
+    * @param mouseY mouse Y position, from the top
+    * @param mouseDown whether the body is pressed
+    * @param keyboardInput
+    *   String generated from the keyboard inputs since the last frame. Usually this will be a single character.
+    *   A `\u0008` character is interpreted as a backspace.
+    */
+  final case class Current(mouseX: Int, mouseY: Int, mouseDown: Boolean, keyboardInput: String) extends InputState:
+
+    def clip(area: Rect): InputState.Current =
+      if (area.isMouseOver(using this)) this
+      else this.copy(mouseX = Int.MinValue, mouseY = Int.MinValue)
+
+  /** Input state at the current point in time and in the previous frame
+    *
+    * @param previousMouseX previous mouse X position, from the left
+    * @param previousMouseY previous mouse Y position, from the top
+    * @param mouseX mouse X position, from the left
+    * @param mouseY mouse Y position, from the top
+    * @param mouseDown whether the body is pressed
+    * @param keyboardInput
+    *   String generated from the keyboard inputs since the last frame. Usually this will be a single character.
+    *   A `\u0008` character is interpreted as a backspace.
+    */
+  final case class Historical(
+      previousMouseX: Int,
+      previousMouseY: Int,
+      mouseX: Int,
+      mouseY: Int,
+      mouseDown: Boolean,
+      keyboardInput: String
+  ) extends InputState:
+
+    /** How much the mouse moved in the X axis */
+    lazy val deltaX: Int =
+      if (previousMouseX == Int.MinValue || mouseX == Int.MinValue) 0
+      else mouseX - previousMouseX
+
+    /** How much the mouse moved in the Y axis */
+    lazy val deltaY: Int =
+      if (previousMouseY == Int.MinValue || mouseY == Int.MinValue) 0
+      else mouseY - previousMouseY
+
+    def clip(area: Rect): InputState.Historical =
+      if (area.isMouseOver(using this)) this
+      else this.copy(mouseX = Int.MinValue, mouseY = Int.MinValue)

--- a/core/src/main/scala/eu/joaocosta/interim/InterIm.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/InterIm.scala
@@ -18,16 +18,17 @@ object InterIm extends api.Primitives with api.Layouts with api.Components with 
     * The method returns a list of operations to render and the result of the body.
     */
   def ui[T](inputState: InputState, uiContext: UiContext)(
-      run: (inputState: InputState, uiContext: UiContext) ?=> T
+      run: (historicalInputState: InputState.Historical, uiContext: UiContext) ?=> T
   ): (List[RenderOp], T) =
     // prepare
     uiContext.ops.clear()
     uiContext.currentZ = 0
     uiContext.hotItem = None
+    val historicalInputState = uiContext.pushInputState(inputState)
     if (inputState.mouseDown) uiContext.selectedItem = None
     // run
-    val res = run(using inputState, uiContext)
+    val res = run(using historicalInputState, uiContext)
     // finish
-    if (!inputState.mouseDown) uiContext.activeItem = None
+    if (!historicalInputState.mouseDown) uiContext.activeItem = None
     // return
     (uiContext.getOrderedOps(), res)

--- a/core/src/main/scala/eu/joaocosta/interim/api/Components.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Components.scala
@@ -11,7 +11,7 @@ object Components extends Components
 
 trait Components:
 
-  type Component[+T] = (inputState: InputState, uiContext: UiContext) ?=> T
+  type Component[+T] = (inputState: InputState.Historical, uiContext: UiContext) ?=> T
 
   trait ComponentWithValue[T]:
     def applyRef(value: Ref[T]): Component[T]
@@ -157,12 +157,8 @@ trait Components:
         val itemStatus = UiContext.registerItem(id, handleArea)
         skin.renderMoveHandle(area, value.get, itemStatus)
         if (itemStatus.active)
-          val handleCenterX = handleArea.x + handleArea.w / 2
-          val handleCenterY = handleArea.y + handleArea.h / 2
-          val mouseX        = summon[InputState].mouseX
-          val mouseY        = summon[InputState].mouseY
-          val deltaX        = mouseX - handleCenterX
-          val deltaY        = mouseY - handleCenterY
+          val deltaX = summon[InputState.Historical].deltaX
+          val deltaY = summon[InputState.Historical].deltaY
           value.modify(_.move(deltaX, deltaY))
         value.get
 

--- a/core/src/main/scala/eu/joaocosta/interim/api/Layouts.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Layouts.scala
@@ -19,11 +19,9 @@ trait Layouts:
   final def clip[T](area: Rect)(
       body: (InputState, UiContext) ?=> T
   )(using inputState: InputState, uiContext: UiContext): T =
-    val newUiContext = uiContext.fork()
-    val newInputState =
-      if (area.isMouseOver) inputState
-      else inputState.copy(mouseX = Int.MinValue, mouseY = Int.MinValue)
-    val result = body(using newInputState, newUiContext)
+    val newUiContext  = uiContext.fork()
+    val newInputState = inputState.clip(area)
+    val result        = body(using newInputState, newUiContext)
     newUiContext.ops.get(newUiContext.currentZ).foreach(_.mapInPlace(_.clip(area)).filterInPlace(!_.area.isEmpty))
     uiContext ++= newUiContext
     result

--- a/core/src/test/scala/eu/joaocosta/interim/UiContextSpec.scala
+++ b/core/src/test/scala/eu/joaocosta/interim/UiContextSpec.scala
@@ -87,3 +87,15 @@ class UiContextSpec extends munit.FunSuite:
         RenderOp.DrawRect(Rect(0, 0, 1, 1), Color(4, 4, 4))
       )
     )
+
+  test("pushInputState should update the historical state"):
+    val uiContext: UiContext = new UiContext()
+    val inputState1          = uiContext.pushInputState(InputState(5, 5, false, ""))
+    assertEquals(inputState1.deltaX, 0)
+    assertEquals(inputState1.deltaY, 0)
+    val inputState2 = uiContext.pushInputState(InputState(6, 7, false, ""))
+    assertEquals(inputState2.deltaX, 1)
+    assertEquals(inputState2.deltaY, 2)
+    val inputState3 = uiContext.pushInputState(InputState(Int.MinValue, 6, false, ""))
+    assertEquals(inputState3.deltaX, 0)
+    assertEquals(inputState3.deltaY, -1)

--- a/examples/snapshot/example-minart-backend.scala
+++ b/examples/snapshot/example-minart-backend.scala
@@ -71,8 +71,8 @@ object MinartBackend:
       .mkString
 
   private def getInputState(canvas: Canvas): InputState = InputState(
-    canvas.getPointerInput().position.map(_.x).getOrElse(0),
-    canvas.getPointerInput().position.map(_.y).getOrElse(0),
+    canvas.getPointerInput().position.map(_.x).getOrElse(Int.MinValue),
+    canvas.getPointerInput().position.map(_.y).getOrElse(Int.MinValue),
     canvas.getPointerInput().isPressed,
     processKeyboard(canvas.getKeyboardInput())
   )


### PR DESCRIPTION
Keep track of the previous mouse position.

This should allow for a better dragging experience and window resizing (both to be implemented)