### PR TITLE
Add mouse area layout

### DIFF
--- a/core/src/main/scala/eu/joaocosta/interim/InterIm.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/InterIm.scala
@@ -25,10 +25,10 @@ object InterIm extends api.Primitives with api.Layouts with api.Components with 
     uiContext.currentZ = 0
     uiContext.hotItem = None
     val historicalInputState = uiContext.pushInputState(inputState)
-    if (inputState.mouseDown) uiContext.selectedItem = None
+    if (inputState.mouseInput.isPressed) uiContext.selectedItem = None
     // run
     val res = run(using historicalInputState, uiContext)
     // finish
-    if (!historicalInputState.mouseDown) uiContext.activeItem = None
+    if (!historicalInputState.mouseInput.isPressed) uiContext.activeItem = None
     // return
     (uiContext.getOrderedOps(), res)

--- a/core/src/main/scala/eu/joaocosta/interim/Rect.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/Rect.scala
@@ -21,7 +21,7 @@ final case class Rect(x: Int, y: Int, w: Int, h: Int):
   /** Checks if the mouse is over this area.
     */
   def isMouseOver(using inputState: InputState): Boolean =
-    !(inputState.mouseX < x || inputState.mouseY < y || inputState.mouseX >= x + w || inputState.mouseY >= y + h)
+    !(inputState.mouseInput.x < x || inputState.mouseInput.y < y || inputState.mouseInput.x >= x + w || inputState.mouseInput.y >= y + h)
 
   /** Translates the area to another position.
     */

--- a/core/src/main/scala/eu/joaocosta/interim/UiContext.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/UiContext.scala
@@ -23,7 +23,7 @@ final class UiContext private (
   ): UiContext.ItemStatus =
     if (area.isMouseOver && hotItem.forall((hotZ, _) => hotZ <= currentZ))
       hotItem = Some(currentZ -> id)
-      if (!passive && (activeItem == None || activeItem == Some(id)) && inputState.mouseDown)
+      if (!passive && (activeItem == None || activeItem == Some(id)) && inputState.mouseInput.isPressed)
         activeItem = Some(id)
         selectedItem = Some(id)
     UiContext.ItemStatus(hotItem.map(_._2) == Some(id), activeItem == Some(id), selectedItem == Some(id))
@@ -33,11 +33,10 @@ final class UiContext private (
 
   private[interim] def pushInputState(inputState: InputState): InputState.Historical =
     val history = InputState.Historical(
-      previousMouseX = previousInputState.map(_.mouseX).getOrElse(Int.MinValue),
-      previousMouseY = previousInputState.map(_.mouseY).getOrElse(Int.MinValue),
-      mouseX = inputState.mouseX,
-      mouseY = inputState.mouseY,
-      mouseDown = inputState.mouseDown,
+      previousMouseInput = previousInputState
+        .map(_.mouseInput)
+        .getOrElse(InputState.MouseInput(Int.MinValue, Int.MinValue, false)),
+      mouseInput = inputState.mouseInput,
       keyboardInput = inputState.keyboardInput
     )
     previousInputState = Some(inputState)

--- a/core/src/main/scala/eu/joaocosta/interim/api/Components.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Components.scala
@@ -36,7 +36,7 @@ trait Components:
     val buttonArea = skin.buttonArea(area)
     val itemStatus = UiContext.registerItem(id, buttonArea)
     skin.renderButton(area, label, itemStatus)
-    itemStatus.hot && itemStatus.active && summon[InputState].mouseDown == false
+    itemStatus.hot && itemStatus.active && summon[InputState].mouseInput.isPressed == false
 
   /** Checkbox component. Returns true if it's enabled, false otherwise.
     */
@@ -46,7 +46,7 @@ trait Components:
         val checkboxArea = skin.checkboxArea(area)
         val itemStatus   = UiContext.registerItem(id, checkboxArea)
         skin.renderCheckbox(area, value.get, itemStatus)
-        if (itemStatus.hot && itemStatus.active && summon[InputState].mouseDown == false) value.modify(!_)
+        if (itemStatus.hot && itemStatus.active && summon[InputState].mouseInput.isPressed == false) value.modify(!_)
         value.get
 
   /** Radio button component. Returns value currently selected.
@@ -65,7 +65,7 @@ trait Components:
       def applyRef(value: Ref[T]): Component[T] =
         val buttonArea = skin.buttonArea(area)
         val itemStatus = UiContext.registerItem(id, buttonArea)
-        if (itemStatus.hot && itemStatus.active && summon[InputState].mouseDown == false)
+        if (itemStatus.hot && itemStatus.active && summon[InputState].mouseInput.isPressed == false)
           value := buttonValue
         if (value.get == buttonValue) skin.renderButton(area, label, itemStatus.copy(hot = true, active = true))
         else skin.renderButton(area, label, itemStatus)
@@ -118,11 +118,11 @@ trait Components:
         skin.renderSlider(area, min, clampedValue, max, itemStatus)
         if (itemStatus.active)
           if (area.w > area.h)
-            val mousePos = summon[InputState].mouseX - sliderArea.x - sliderSize / 2
+            val mousePos = summon[InputState].mouseInput.x - sliderArea.x - sliderSize / 2
             val maxPos   = sliderArea.w - sliderSize
             value := math.max(min, math.min(min + (mousePos * range) / maxPos, max))
           else
-            val mousePos = summon[InputState].mouseY - sliderArea.y - sliderSize / 2
+            val mousePos = summon[InputState].mouseInput.y - sliderArea.y - sliderSize / 2
             val maxPos   = sliderArea.h - sliderSize
             value := math.max(min, math.min((mousePos * range) / maxPos, max))
         value.get

--- a/core/src/main/scala/eu/joaocosta/interim/api/Layouts.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Layouts.scala
@@ -121,3 +121,16 @@ trait Layouts:
         currentW -= absWidth + padding
         area.copy(x = areaX, w = absWidth)
     body(generateRect)
+
+  /** Handle mouse events inside a specified area.
+    *
+    * The body receives an optional MouseInput with the coordinates adjusted to be relative
+    * to the enclosing area.
+    * If the mouse is outside of the area, the body receives None.
+    */
+  final def mouseArea[T](area: Rect)(body: Option[InputState.MouseInput] => T)(using inputState: InputState): T =
+    body(
+      Option.when(area.isMouseOver)(
+        inputState.mouseInput.copy(x = inputState.mouseInput.x - area.x, y = inputState.mouseInput.y - area.y)
+      )
+    )

--- a/core/src/test/scala/eu/joaocosta/interim/api/LayoutsSpec.scala
+++ b/core/src/test/scala/eu/joaocosta/interim/api/LayoutsSpec.scala
@@ -87,3 +87,10 @@ class LayoutsSpec extends munit.FunSuite:
     val expected =
       Vector(Rect(10, 10, 16, 100), Rect(78, 10, 32, 100), Rect(34, 10, 36, 100))
     assertEquals(areas, expected)
+
+  test("mouseArea passes un updated mouse input"):
+    val inputState = InputState(10, 10, false, "")
+    val inArea     = Layouts.mouseArea(Rect(5, 5, 10, 10))(identity)(using inputState)
+    assertEquals(inArea, Some(InputState.MouseInput(5, 5, false)))
+    val outsideArea = Layouts.mouseArea(Rect(5, 5, 1, 1))(identity)(using inputState)
+    assertEquals(outsideArea, None)


### PR DESCRIPTION
Add a new mouse area layout.

This is not really useful for laying out interim components, but it's useful for custom components that need to handle the mouse input.
With this one can do something like `mouseArea(area)(mouse=> custom(area.shrink(5), Color(0, 0, 0), CustomData(mouse)))` and then later have a `def customComponentApp(data: CustomData): ImageData`, where the backend just needs to render the `ImageData` in the correct position. This is a bit less cumbersome that to have to constantly keep track of the custom component position.