### PR TITLE
Add basic Custom handling example to the example MinartBackend

### DIFF
--- a/examples/snapshot/example-minart-backend.scala
+++ b/examples/snapshot/example-minart-backend.scala
@@ -88,7 +88,9 @@ object MinartBackend:
           canvas
             .blit(charSprite, BlendMode.ColorMask(MinartColor(255, 0, 255)))(x, y)
         }
-      case RenderOp.Custom(Rect(x, y, w, h), color, _) =>
+      case RenderOp.Custom(Rect(x, y, w, h), color, surface: Surface) =>
+        canvas.blit(surface)(x, y, 0, 0, w, h)
+      case RenderOp.Custom(Rect(x, y, w, h), color, data) =>
         canvas.fillRegion(x, y, w, h, MinartColor(color.r, color.g, color.b))
     }
 


### PR DESCRIPTION
Adds some logic to draw images to the example backend.

This is not yet used in any of the examples, but I think it's still a nice way for users to see how Custom ops can be implemented. I might add a better example later.