### PR TITLE
Small window fixes

### DIFF
--- a/core/src/main/scala/eu/joaocosta/interim/api/Components.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Components.scala
@@ -191,6 +191,6 @@ trait Components:
         val handleArea = skin.closeHandleArea(area)
         val itemStatus = UiContext.registerItem(id, handleArea)
         skin.renderCloseHandle(area, itemStatus)
-        if (itemStatus.active)
+        if (itemStatus.clicked)
           value.modify(_.close)
         value.get

--- a/core/src/main/scala/eu/joaocosta/interim/api/Panels.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Panels.scala
@@ -73,5 +73,5 @@ trait Panels:
             handleSkin
           )(windowArea)
         panelStateRef.modify(_.copy(value = newArea))
-      (Some(res), panelStateRef.get)
+      (Option.when(panelStateRef.get.isOpen)(res), panelStateRef.get)
     else (None, panelStateRef.get)


### PR DESCRIPTION
Fixes a 1 frame delay when closing windows (which would make the window not closable if the area was not a `Ref`) and makes the close button's behavior consistent with other buttons.