### PR TITLE
Make it easier to implement a ComponentWithValue

### DIFF
--- a/core/src/main/scala/eu/joaocosta/interim/Ref.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/Ref.scala
@@ -19,11 +19,18 @@ final case class Ref[T](private var value: T):
     value = newValue
     this
 
-  /** Modifies the value pf this Ref.
+  /** Modifies the value of this Ref.
     * Shorthand for `ref := f(ref.value)`
     */
   def modify(f: T => T): this.type =
     value = f(value)
+    this
+
+  /** Modifies the value of this Ref if the condition is true.
+    * Shorthand for `if (cond) ref := f(ref.value) else ref`
+    */
+  def modifyIf(cond: Boolean)(f: T => T): this.type =
+    if (cond) value = f(value)
     this
 
 object Ref:

--- a/core/src/test/scala/eu/joaocosta/interim/RefSpec.scala
+++ b/core/src/test/scala/eu/joaocosta/interim/RefSpec.scala
@@ -14,6 +14,14 @@ class RefSpec extends munit.FunSuite:
     assertEquals(x.modify(_ + 1).get, 2)
     assertEquals(x.get, 2)
 
+  test("Ref values can be modified with modifyIf"):
+    val x = Ref(1)
+
+    assertEquals(x.modifyIf(false)(_ + 1).get, 1)
+    assertEquals(x.get, 1)
+    assertEquals(x.modifyIf(true)(_ + 1).get, 2)
+    assertEquals(x.get, 2)
+
   test("withRef allows to use a temporary Ref value"):
     val result = Ref.withRef(0): ref =>
       ref.modify(_ + 2)


### PR DESCRIPTION
New components implemented on top of `ComponentWithValue` are a bit of a pain to implement, and one of the reasons is that pretty much all implementations add with `value.get`.

This PR changes it so that `ComponentWithValue` is implemented with a `render(value: Ref[T]): Component[Unit]` (`applyRef` basically calls this and returns the `Ref` in the end).

It also adds a `Ref#modifyIf` helper method, as one of the pain points was the amount of code that uses something akin to `if (condition) value.modify(f)`.
Instead of forcing users to write `if (condition) value.modify(f) else value`, they can just use this new helper.