### PR TITLE
Add rectangleOutline primitive

### DIFF
--- a/core/src/main/scala/eu/joaocosta/interim/api/Primitives.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Primitives.scala
@@ -11,10 +11,22 @@ object Primitives extends Primitives
 
 trait Primitives:
 
-  /** Draws a rectangle filling a the specified area with a color.
+  /** Draws a rectangle filling the specified area with a color.
     */
   final def rectangle(area: Rect, color: Color)(using uiContext: UiContext): Unit =
     uiContext.pushRenderOp(RenderOp.DrawRect(area, color))
+
+  /** Draws the outline a rectangle inside the specified area with a color.
+    */
+  final def rectangleOutline(area: Rect, color: Color, strokeSize: Int)(using uiContext: UiContext): Unit =
+    val top    = area.copy(h = strokeSize)
+    val bottom = top.move(dx = 0, dy = area.h - strokeSize)
+    val left   = area.copy(w = strokeSize)
+    val right  = left.move(dx = area.w - strokeSize, dy = 0)
+    rectangle(top, color)
+    rectangle(bottom, color)
+    rectangle(left, color)
+    rectangle(right, color)
 
   /** Draws a block of text in the specified area with a color.
     *

--- a/core/src/main/scala/eu/joaocosta/interim/skins/CheckboxSkin.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/skins/CheckboxSkin.scala
@@ -30,11 +30,7 @@ object CheckboxSkin extends DefaultSkin:
           rectangle(checkboxArea, hotColor)
         case UiContext.ItemStatus(_, true, _, _) =>
           rectangle(checkboxArea, activeColor)
-      if (value)
-        rectangle(
-          checkboxArea.shrink(padding),
-          checkColor
-        )
+      if (value) rectangle(checkboxArea.shrink(padding), checkColor)
 
   val lightDefault: Default = Default(
     padding = 2,

--- a/core/src/main/scala/eu/joaocosta/interim/skins/TextInputSkin.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/skins/TextInputSkin.scala
@@ -26,11 +26,11 @@ object TextInputSkin extends DefaultSkin:
       val textInputArea = this.textInputArea(area)
       itemStatus match
         case UiContext.ItemStatus(_, _, true, _) | UiContext.ItemStatus(_, true, _, _) =>
-          rectangle(area, activeColor)
+          rectangleOutline(area, activeColor, border)
         case UiContext.ItemStatus(true, _, _, _) =>
-          rectangle(area, hotColor)
+          rectangleOutline(area, hotColor, border)
         case _ =>
-          rectangle(area, inactiveColor)
+          rectangleOutline(area, inactiveColor, border)
       rectangle(textInputArea, textAreaColor)
       text(
         textInputArea.shrink(border),

--- a/core/src/main/scala/eu/joaocosta/interim/skins/WindowSkin.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/skins/WindowSkin.scala
@@ -17,9 +17,11 @@ object WindowSkin extends DefaultSkin:
 
   final case class Default(
       font: Font,
+      border: Int,
       textColor: Color,
       panelColor: Color,
-      titleColor: Color
+      titleColor: Color,
+      borderColor: Color
   ) extends WindowSkin:
 
     def titleArea(area: Rect): Rect =
@@ -48,17 +50,22 @@ object WindowSkin extends DefaultSkin:
       rectangle(titleArea, titleColor)
       text(titleArea, textColor, title, font, HorizontalAlignment.Center, VerticalAlignment.Center)
       rectangle(panelArea, panelColor)
+      rectangleOutline(area, borderColor, border)
 
   val lightDefault: Default = Default(
     font = Font.default,
+    border = 1,
     textColor = ColorScheme.black,
     panelColor = ColorScheme.white,
-    titleColor = ColorScheme.lightGray
+    titleColor = ColorScheme.lightGray,
+    borderColor = ColorScheme.darkGray
   )
 
   val darkDefault: Default = Default(
     font = Font.default,
+    border = 1,
     textColor = ColorScheme.white,
     panelColor = ColorScheme.black,
-    titleColor = ColorScheme.darkGray
+    titleColor = ColorScheme.darkGray,
+    borderColor = ColorScheme.lightGray
   )


### PR DESCRIPTION
Adds a new `rectangleOutline` primitive.

This simply generates 4 rectangles, but I feel like without this it's to tempting to just put a huge rectangle inside of another huge rectangle to achieve this effect (with a ton of overdraw in the process)

This also adds a small border to the default window skin.

![imagem](https://github.com/JD557/interim/assets/1187242/3ab5008e-bca0-49f8-bdce-246c2e3a694f)
![imagem](https://github.com/JD557/interim/assets/1187242/241b77a0-4951-40e4-85f7-17e62014d1ae)

