### PR TITLE
Make mouse position optional

### DIFF
--- a/core/src/main/scala/eu/joaocosta/interim/Rect.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/Rect.scala
@@ -23,7 +23,9 @@ final case class Rect(x: Int, y: Int, w: Int, h: Int):
   /** Checks if the mouse is over this area.
     */
   def isMouseOver(using inputState: InputState): Boolean =
-    !(inputState.mouseInput.x < x || inputState.mouseInput.y < y || inputState.mouseInput.x >= x + w || inputState.mouseInput.y >= y + h)
+    inputState.mouseInput.position.exists((mouseX, mouseY) =>
+      !(mouseX < x || mouseY < y || mouseX >= x + w || mouseY >= y + h)
+    )
 
   /** Translates the area to another position.
     */

--- a/core/src/main/scala/eu/joaocosta/interim/UiContext.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/UiContext.scala
@@ -39,7 +39,7 @@ final class UiContext private (
     val history = InputState.Historical(
       previousMouseInput = previousInputState
         .map(_.mouseInput)
-        .getOrElse(InputState.MouseInput(Int.MinValue, Int.MinValue, false)),
+        .getOrElse(InputState.MouseInput(None, false)),
       mouseInput = inputState.mouseInput,
       keyboardInput = inputState.keyboardInput
     )

--- a/core/src/main/scala/eu/joaocosta/interim/api/Components.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Components.scala
@@ -117,14 +117,15 @@ trait Components:
         val clampedValue = math.max(min, math.min(value.get, max))
         skin.renderSlider(area, min, clampedValue, max, itemStatus)
         if (itemStatus.active)
-          if (area.w > area.h)
-            val mousePos = summon[InputState].mouseInput.x - sliderArea.x - sliderSize / 2
-            val maxPos   = sliderArea.w - sliderSize
-            value := math.max(min, math.min(min + (mousePos * range) / maxPos, max))
-          else
-            val mousePos = summon[InputState].mouseInput.y - sliderArea.y - sliderSize / 2
-            val maxPos   = sliderArea.h - sliderSize
-            value := math.max(min, math.min((mousePos * range) / maxPos, max))
+          summon[InputState].mouseInput.position.foreach: (mouseX, mouseY) =>
+            if (area.w > area.h)
+              val mousePos = mouseX - sliderArea.x - sliderSize / 2
+              val maxPos   = sliderArea.w - sliderSize
+              value := math.max(min, math.min(min + (mousePos * range) / maxPos, max))
+            else
+              val mousePos = mouseY - sliderArea.y - sliderSize / 2
+              val maxPos   = sliderArea.h - sliderSize
+              value := math.max(min, math.min((mousePos * range) / maxPos, max))
 
   /** Text input component. Returns the current string inputed.
     */

--- a/core/src/main/scala/eu/joaocosta/interim/api/Layouts.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/api/Layouts.scala
@@ -131,6 +131,6 @@ trait Layouts:
   final def mouseArea[T](area: Rect)(body: Option[InputState.MouseInput] => T)(using inputState: InputState): T =
     body(
       Option.when(area.isMouseOver)(
-        inputState.mouseInput.copy(x = inputState.mouseInput.x - area.x, y = inputState.mouseInput.y - area.y)
+        inputState.mouseInput.copy(position = inputState.mouseInput.position.map((x, y) => (x - area.x, y - area.y)))
       )
     )

--- a/core/src/test/scala/eu/joaocosta/interim/UiContextSpec.scala
+++ b/core/src/test/scala/eu/joaocosta/interim/UiContextSpec.scala
@@ -111,6 +111,6 @@ class UiContextSpec extends munit.FunSuite:
     val inputState2 = uiContext.pushInputState(InputState(6, 7, false, ""))
     assertEquals(inputState2.deltaX, 1)
     assertEquals(inputState2.deltaY, 2)
-    val inputState3 = uiContext.pushInputState(InputState(Int.MinValue, 6, false, ""))
+    val inputState3 = uiContext.pushInputState(InputState(false, ""))
     assertEquals(inputState3.deltaX, 0)
-    assertEquals(inputState3.deltaY, -1)
+    assertEquals(inputState3.deltaY, 0)

--- a/examples/snapshot/example-minart-backend.scala
+++ b/examples/snapshot/example-minart-backend.scala
@@ -71,8 +71,7 @@ object MinartBackend:
       .mkString
 
   private def getInputState(canvas: Canvas): InputState = InputState(
-    canvas.getPointerInput().position.map(_.x).getOrElse(Int.MinValue),
-    canvas.getPointerInput().position.map(_.y).getOrElse(Int.MinValue),
+    canvas.getPointerInput().position.map(pos => (pos.x, pos.y)),
     canvas.getPointerInput().isPressed,
     processKeyboard(canvas.getKeyboardInput())
   )


### PR DESCRIPTION
Makes the mouse position optional instead of doing trickery with `Int.MinValue`.

Components such as sliders now work as expected when the cursor moves out of the window.