### PR TITLE
Add modifyRefs method

### DIFF
--- a/core/src/main/scala/eu/joaocosta/interim/Ref.scala
+++ b/core/src/main/scala/eu/joaocosta/interim/Ref.scala
@@ -73,3 +73,13 @@ extension [T](x: T) def asRef(block: Ref[T] => Unit): T = Ref.withRef(x)(block)
 extension [T <: Product](x: T)
   def asRefs(using mirror: Mirror.ProductOf[T])(block: Tuple.Map[mirror.MirroredElemTypes, Ref] => Unit): T =
     Ref.withRefs(x)(block)
+
+/** Destructures a Ref into multiple Refs and passes it to a block, returning the updated Ref.
+  *
+  * Useful to work with large state objects.
+  *
+  * Equivalent to `x.modify(_.asRefs(block))`
+  */
+extension [T <: Product](x: Ref[T])
+  def modifyRefs(using mirror: Mirror.ProductOf[T])(block: Tuple.Map[mirror.MirroredElemTypes, Ref] => Unit): Ref[T] =
+    x.modify(_.asRefs(block))

--- a/core/src/test/scala/eu/joaocosta/interim/RefSpec.scala
+++ b/core/src/test/scala/eu/joaocosta/interim/RefSpec.scala
@@ -27,7 +27,7 @@ class RefSpec extends munit.FunSuite:
       ref.modify(_ + 2)
     assertEquals(result, 2)
 
-  test("withRefs allows to build a case class from temporary Ref value"):
+  test("withRefs allows to build a case class from temporary Ref values"):
     case class Foo(x: Int, y: String)
     val result = Ref.withRefs(Foo(1, "asd")): (x, y) =>
       x := 2
@@ -39,9 +39,17 @@ class RefSpec extends munit.FunSuite:
       ref.modify(_ + 2)
     assertEquals(result, 2)
 
-  test("asRefs allows to build a case class from temporary Ref value"):
+  test("asRefs allows to build a case class from temporary Ref values"):
     case class Foo(x: Int, y: String)
     val result = Foo(1, "asd").asRefs: (x, y) =>
       x := 2
       y := "dsa"
     assertEquals(result, Foo(2, "dsa"))
+
+  test("modifyRefs allows to modify a case class Ref from temporary Ref values"):
+    case class Foo(x: Int, y: String)
+    val ref = Ref(Foo(1, "asd"))
+    ref.modifyRefs: (x, y) =>
+      x := 2
+      y := "dsa"
+    assertEquals(ref.get, Foo(2, "dsa"))


### PR DESCRIPTION
Adds a new `modifyRefs` extension method on `Ref[T]` to allow fields of a `Ref` to be updated individually.

This is quite helpful when implementing custom components that need to manipulate multiple fields.