### PR TITLE
Simplify skins color scheme

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/interim/skins/ButtonSkin.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/interim/skins/ButtonSkin.scala
@@ -15,11 +15,7 @@ object ButtonSkin extends DefaultSkin:
   final case class Default(
       buttonHeight: Int,
       font: Font,
-      shadowColor: Color,
-      textColor: Color,
-      inactiveColor: Color,
-      hotColor: Color,
-      activeColor: Color
+      colorScheme: ColorScheme
   ) extends ButtonSkin:
 
     def buttonArea(area: Rect): Rect =
@@ -32,38 +28,30 @@ object ButtonSkin extends DefaultSkin:
       val clickedArea = buttonArea.move(dx = 0, dy = buttonHeight)
       itemStatus match
         case UiContext.ItemStatus(false, false, _, _) =>
-          rectangle(area.copy(y = buttonArea.y2, h = buttonHeight), shadowColor)
-          rectangle(buttonArea, inactiveColor)
+          rectangle(area.copy(y = buttonArea.y2, h = buttonHeight), colorScheme.primaryShadow)
+          rectangle(buttonArea, colorScheme.primary)
         case UiContext.ItemStatus(true, false, _, _) =>
-          rectangle(area.copy(y = buttonArea.y2, h = buttonHeight), inactiveColor)
-          rectangle(buttonArea, hotColor)
+          rectangle(area.copy(y = buttonArea.y2, h = buttonHeight), colorScheme.primary)
+          rectangle(buttonArea, colorScheme.primaryHighlight)
         case UiContext.ItemStatus(false, true, _, _) =>
-          rectangle(area.copy(y = buttonArea.y2, h = buttonHeight), inactiveColor)
-          rectangle(buttonArea, activeColor)
+          rectangle(area.copy(y = buttonArea.y2, h = buttonHeight), colorScheme.primary)
+          rectangle(buttonArea, colorScheme.primaryHighlight)
         case UiContext.ItemStatus(true, true, _, _) =>
-          rectangle(clickedArea, activeColor)
+          rectangle(clickedArea, colorScheme.primaryHighlight)
       itemStatus match
         case UiContext.ItemStatus(true, true, _, _) =>
-          text(clickedArea, textColor, label, font, HorizontalAlignment.Center, VerticalAlignment.Center)
+          text(clickedArea, colorScheme.text, label, font, HorizontalAlignment.Center, VerticalAlignment.Center)
         case _ =>
-          text(buttonArea, textColor, label, font, HorizontalAlignment.Center, VerticalAlignment.Center)
+          text(buttonArea, colorScheme.text, label, font, HorizontalAlignment.Center, VerticalAlignment.Center)
 
   val lightDefault: Default = Default(
     buttonHeight = 3,
     font = Font.default,
-    shadowColor = ColorScheme.lightPrimaryShadow,
-    textColor = ColorScheme.black,
-    inactiveColor = ColorScheme.lightPrimary,
-    hotColor = ColorScheme.lightPrimaryHighlight,
-    activeColor = ColorScheme.lightPrimaryHighlight
+    colorScheme = ColorScheme.lightScheme
   )
 
   val darkDefault: Default = Default(
     buttonHeight = 3,
     font = Font.default,
-    shadowColor = ColorScheme.darkPrimaryShadow,
-    textColor = ColorScheme.white,
-    inactiveColor = ColorScheme.darkPrimary,
-    hotColor = ColorScheme.darkPrimaryHighlight,
-    activeColor = ColorScheme.darkPrimaryHighlight
+    colorScheme = ColorScheme.darkScheme
   )

--- a/core/shared/src/main/scala/eu/joaocosta/interim/skins/CheckboxSkin.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/interim/skins/CheckboxSkin.scala
@@ -11,10 +11,7 @@ object CheckboxSkin extends DefaultSkin:
 
   final case class Default(
       padding: Int,
-      inactiveColor: Color,
-      hotColor: Color,
-      activeColor: Color,
-      checkColor: Color
+      colorScheme: ColorScheme
   ) extends CheckboxSkin:
 
     def checkboxArea(area: Rect): Rect =
@@ -25,25 +22,19 @@ object CheckboxSkin extends DefaultSkin:
       val checkboxArea = this.checkboxArea(area)
       itemStatus match
         case UiContext.ItemStatus(false, false, _, _) =>
-          rectangle(checkboxArea, inactiveColor)
+          rectangle(checkboxArea, colorScheme.secondary)
         case UiContext.ItemStatus(true, false, _, _) =>
-          rectangle(checkboxArea, hotColor)
+          rectangle(checkboxArea, colorScheme.secondaryHighlight)
         case UiContext.ItemStatus(_, true, _, _) =>
-          rectangle(checkboxArea, activeColor)
-      if (value) rectangle(checkboxArea.shrink(padding), checkColor)
+          rectangle(checkboxArea, colorScheme.primaryHighlight)
+      if (value) rectangle(checkboxArea.shrink(padding), colorScheme.icon)
 
   val lightDefault: Default = Default(
     padding = 2,
-    inactiveColor = ColorScheme.lightGray,
-    hotColor = ColorScheme.lightPrimary,
-    activeColor = ColorScheme.lightPrimaryHighlight,
-    checkColor = ColorScheme.black
+    ColorScheme.lightScheme
   )
 
   val darkDefault: Default = Default(
     padding = 2,
-    inactiveColor = ColorScheme.darkGray,
-    hotColor = ColorScheme.darkPrimary,
-    activeColor = ColorScheme.darkPrimaryHighlight,
-    checkColor = ColorScheme.white
+    ColorScheme.darkScheme
   )

--- a/core/shared/src/main/scala/eu/joaocosta/interim/skins/ColorScheme.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/interim/skins/ColorScheme.scala
@@ -2,6 +2,19 @@ package eu.joaocosta.interim.skins
 
 import eu.joaocosta.interim.Color
 
+final case class ColorScheme(
+    background: Color,         // white / black
+    text: Color,               // black / white
+    icon: Color,               // black / lightGray
+    iconHighlight: Color,      // pureGray / white
+    primary: Color,            // lightPrimary / darkPrimary
+    primaryShadow: Color,      // lightPrimaryShadow / darkPrimaryShadow
+    primaryHighlight: Color,   // lightPrimaryHighlight / darkPrimaryHighlight
+    secondary: Color,          // lightGray / darkGray
+    secondaryHighlight: Color, // pureGray / pureGray
+    borderColor: Color         // pureGray / pureGray
+)
+
 /** Internal default color scheme used by InterIm's default skins */
 object ColorScheme:
   val white     = Color(246, 247, 251)
@@ -17,6 +30,31 @@ object ColorScheme:
   val darkPrimary          = Color(97, 31, 125)
   val darkPrimaryShadow    = Color(67, 24, 92)
   val darkPrimaryHighlight = Color(130, 38, 158)
+
+  val lightScheme = ColorScheme(
+    background = white,
+    text = black,
+    icon = black,
+    iconHighlight = pureGray,
+    primary = lightPrimary,
+    primaryShadow = lightPrimaryShadow,
+    primaryHighlight = lightPrimaryHighlight,
+    secondary = lightGray,
+    secondaryHighlight = pureGray,
+    borderColor = pureGray
+  )
+  val darkScheme = ColorScheme(
+    background = black,
+    text = white,
+    icon = lightGray,
+    iconHighlight = white,
+    primary = darkPrimary,
+    primaryShadow = darkPrimaryShadow,
+    primaryHighlight = darkPrimaryHighlight,
+    secondary = darkGray,
+    secondaryHighlight = pureGray,
+    borderColor = pureGray
+  )
 
   private var darkMode = false
 

--- a/core/shared/src/main/scala/eu/joaocosta/interim/skins/HandleSkin.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/interim/skins/HandleSkin.scala
@@ -14,11 +14,7 @@ trait HandleSkin:
 
 object HandleSkin extends DefaultSkin:
 
-  final case class Default(
-      inactiveColor: Color,
-      hotColor: Color,
-      activeColor: Color
-  ) extends HandleSkin:
+  final case class Default(colorScheme: ColorScheme) extends HandleSkin:
 
     def moveHandleArea(area: Rect): Rect =
       val smallSide = math.min(area.w, area.h)
@@ -27,9 +23,9 @@ object HandleSkin extends DefaultSkin:
     def renderMoveHandle(area: Rect, itemStatus: UiContext.ItemStatus)(using uiContext: UiContext): Unit =
       val handleArea = this.moveHandleArea(area)
       val color = itemStatus match
-        case UiContext.ItemStatus(false, false, _, _) => inactiveColor
-        case UiContext.ItemStatus(true, false, _, _)  => hotColor
-        case UiContext.ItemStatus(_, true, _, _)      => activeColor
+        case UiContext.ItemStatus(false, false, _, _) => colorScheme.icon
+        case UiContext.ItemStatus(true, false, _, _)  => colorScheme.iconHighlight
+        case UiContext.ItemStatus(_, true, _, _)      => colorScheme.primaryHighlight
       val lineHeight = handleArea.h / 3
       rectangle(handleArea.copy(h = lineHeight), color)
       rectangle(handleArea.copy(y = handleArea.y + 2 * lineHeight, h = lineHeight), color)
@@ -41,9 +37,9 @@ object HandleSkin extends DefaultSkin:
     def renderCloseHandle(area: Rect, itemStatus: UiContext.ItemStatus)(using uiContext: UiContext): Unit =
       val handleArea = this.closeHandleArea(area)
       val color = itemStatus match
-        case UiContext.ItemStatus(false, false, _, _) => inactiveColor
-        case UiContext.ItemStatus(true, false, _, _)  => hotColor
-        case UiContext.ItemStatus(_, true, _, _)      => activeColor
+        case UiContext.ItemStatus(false, false, _, _) => colorScheme.icon
+        case UiContext.ItemStatus(true, false, _, _)  => colorScheme.iconHighlight
+        case UiContext.ItemStatus(_, true, _, _)      => colorScheme.primaryHighlight
       rectangle(handleArea, color)
 
     def resizeHandleArea(area: Rect): Rect =
@@ -53,21 +49,13 @@ object HandleSkin extends DefaultSkin:
     def renderResizeHandle(area: Rect, itemStatus: UiContext.ItemStatus)(using uiContext: UiContext): Unit =
       val handleArea = this.resizeHandleArea(area)
       val color = itemStatus match
-        case UiContext.ItemStatus(false, false, _, _) => inactiveColor
-        case UiContext.ItemStatus(true, false, _, _)  => hotColor
-        case UiContext.ItemStatus(_, true, _, _)      => activeColor
+        case UiContext.ItemStatus(false, false, _, _) => colorScheme.icon
+        case UiContext.ItemStatus(true, false, _, _)  => colorScheme.iconHighlight
+        case UiContext.ItemStatus(_, true, _, _)      => colorScheme.primaryHighlight
       val lineSize = handleArea.h / 3
       rectangle(handleArea.move(dx = handleArea.w - lineSize, dy = 0).copy(w = lineSize), color)
       rectangle(handleArea.move(dx = 0, dy = handleArea.h - lineSize).copy(h = lineSize), color)
 
-  val lightDefault: Default = Default(
-    inactiveColor = ColorScheme.black,
-    hotColor = ColorScheme.pureGray,
-    activeColor = ColorScheme.lightPrimaryHighlight
-  )
+  val lightDefault: Default = Default(ColorScheme.lightScheme)
 
-  val darkDefault: Default = Default(
-    inactiveColor = ColorScheme.lightGray,
-    hotColor = ColorScheme.white,
-    activeColor = ColorScheme.darkPrimaryHighlight
-  )
+  val darkDefault: Default = Default(ColorScheme.darkScheme)

--- a/core/shared/src/main/scala/eu/joaocosta/interim/skins/SelectSkin.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/interim/skins/SelectSkin.scala
@@ -17,12 +17,9 @@ trait SelectSkin:
 object SelectSkin extends DefaultSkin:
 
   final case class Default(
-      border: Int,
+      padding: Int,
       font: Font,
-      inactiveColor: Color,
-      hotColor: Color,
-      activeColor: Color,
-      textColor: Color
+      colorScheme: ColorScheme
   ) extends SelectSkin:
 
     // Select box
@@ -36,14 +33,14 @@ object SelectSkin extends DefaultSkin:
       val selectedLabel = labels.applyOrElse(value, _ => "")
       itemStatus match
         case UiContext.ItemStatus(_, _, true, _) | UiContext.ItemStatus(_, true, _, _) =>
-          rectangle(selectBoxArea, activeColor)
+          rectangle(selectBoxArea, colorScheme.primaryHighlight)
         case UiContext.ItemStatus(true, _, _, _) =>
-          rectangle(selectBoxArea, hotColor)
+          rectangle(selectBoxArea, colorScheme.secondaryHighlight)
         case UiContext.ItemStatus(_, _, _, _) =>
-          rectangle(selectBoxArea, inactiveColor)
+          rectangle(selectBoxArea, colorScheme.secondary)
       text(
-        selectBoxArea.shrink(border),
-        textColor,
+        selectBoxArea.shrink(padding),
+        colorScheme.text,
         selectedLabel,
         font,
         TextLayout.HorizontalAlignment.Left,
@@ -62,14 +59,14 @@ object SelectSkin extends DefaultSkin:
       onTop:
         itemStatus match
           case UiContext.ItemStatus(_, _, true, _) | UiContext.ItemStatus(_, true, _, _) =>
-            rectangle(selectOptionArea, activeColor)
+            rectangle(selectOptionArea, colorScheme.primaryHighlight)
           case UiContext.ItemStatus(true, _, _, _) =>
-            rectangle(selectOptionArea, hotColor)
+            rectangle(selectOptionArea, colorScheme.secondaryHighlight)
           case _ =>
-            rectangle(selectOptionArea, inactiveColor)
+            rectangle(selectOptionArea, colorScheme.secondary)
         text(
-          selectOptionArea.shrink(border),
-          textColor,
+          selectOptionArea.shrink(padding),
+          colorScheme.text,
           optionLabel,
           font,
           TextLayout.HorizontalAlignment.Left,
@@ -77,19 +74,13 @@ object SelectSkin extends DefaultSkin:
         )
 
   val lightDefault: Default = Default(
-    border = 2,
+    padding = 2,
     font = Font.default,
-    inactiveColor = ColorScheme.lightGray,
-    hotColor = ColorScheme.pureGray,
-    activeColor = ColorScheme.lightPrimaryHighlight,
-    textColor = ColorScheme.black
+    colorScheme = ColorScheme.lightScheme
   )
 
   val darkDefault: Default = Default(
-    border = 2,
+    padding = 2,
     font = Font.default,
-    inactiveColor = ColorScheme.darkGray,
-    hotColor = ColorScheme.pureGray,
-    activeColor = ColorScheme.darkPrimaryHighlight,
-    textColor = ColorScheme.white
+    colorScheme = ColorScheme.darkScheme
   )

--- a/core/shared/src/main/scala/eu/joaocosta/interim/skins/SliderSkin.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/interim/skins/SliderSkin.scala
@@ -14,10 +14,7 @@ object SliderSkin extends DefaultSkin:
   final case class Default(
       padding: Int,
       minSliderSize: Int,
-      scrollbarColor: Color,
-      inactiveColor: Color,
-      hotColor: Color,
-      activeColor: Color
+      colorScheme: ColorScheme
   ) extends SliderSkin:
 
     def sliderArea(area: Rect): Rect = area.shrink(padding)
@@ -39,29 +36,23 @@ object SliderSkin extends DefaultSkin:
           Rect(0, 0, sliderArea.w, math.max(minSliderSize, sliderArea.h / steps))
             .centerAt(sliderArea.centerX, 0)
             .copy(y = sliderArea.y + deltaY)
-      rectangle(area, scrollbarColor) // Scrollbar
+      rectangle(area, colorScheme.secondary)
       itemStatus match
         case UiContext.ItemStatus(false, false, _, _) =>
-          rectangle(sliderRect, inactiveColor)
+          rectangle(sliderRect, colorScheme.primaryShadow)
         case UiContext.ItemStatus(true, false, _, _) =>
-          rectangle(sliderRect, hotColor)
+          rectangle(sliderRect, colorScheme.primary)
         case _ =>
-          rectangle(sliderRect, activeColor)
+          rectangle(sliderRect, colorScheme.primaryHighlight)
 
   val lightDefault: Default = Default(
     padding = 1,
     minSliderSize = 8,
-    scrollbarColor = ColorScheme.lightGray,
-    inactiveColor = ColorScheme.lightPrimaryShadow,
-    hotColor = ColorScheme.lightPrimary,
-    activeColor = ColorScheme.lightPrimaryHighlight
+    ColorScheme.lightScheme
   )
 
   val darkDefault: Default = Default(
     padding = 1,
     minSliderSize = 8,
-    scrollbarColor = ColorScheme.darkGray,
-    inactiveColor = ColorScheme.darkPrimaryShadow,
-    hotColor = ColorScheme.darkPrimary,
-    activeColor = ColorScheme.darkPrimaryHighlight
+    ColorScheme.darkScheme
   )

--- a/core/shared/src/main/scala/eu/joaocosta/interim/skins/TextInputSkin.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/interim/skins/TextInputSkin.scala
@@ -13,12 +13,7 @@ object TextInputSkin extends DefaultSkin:
       border: Int,
       activeBorder: Int,
       font: Font,
-      inactiveColor: Color,
-      hotColor: Color,
-      activeColor: Color,
-      textAreaColor: Color,
-      activeTextAreaColor: Color,
-      textColor: Color
+      colorScheme: ColorScheme
   ) extends TextInputSkin:
 
     def textInputArea(area: Rect): Rect = area
@@ -27,17 +22,17 @@ object TextInputSkin extends DefaultSkin:
       val textInputArea = this.textInputArea(area)
       itemStatus match
         case UiContext.ItemStatus(_, _, true, _) | UiContext.ItemStatus(_, true, _, _) =>
-          rectangle(textInputArea, activeTextAreaColor)
-          rectangleOutline(area, activeColor, activeBorder)
+          rectangle(textInputArea, colorScheme.background)
+          rectangleOutline(area, colorScheme.primaryHighlight, activeBorder)
         case UiContext.ItemStatus(true, _, _, _) =>
-          rectangle(textInputArea, textAreaColor)
-          rectangleOutline(area, hotColor, border)
+          rectangle(textInputArea, colorScheme.secondary)
+          rectangleOutline(area, colorScheme.primary, border)
         case _ =>
-          rectangle(textInputArea, textAreaColor)
-          rectangleOutline(area, inactiveColor, border)
+          rectangle(textInputArea, colorScheme.secondary)
+          rectangleOutline(area, colorScheme.borderColor, border)
       text(
         textInputArea.shrink(activeBorder),
-        textColor,
+        colorScheme.text,
         value,
         font,
         TextLayout.HorizontalAlignment.Left,
@@ -48,22 +43,12 @@ object TextInputSkin extends DefaultSkin:
     border = 1,
     activeBorder = 2,
     font = Font.default,
-    inactiveColor = ColorScheme.pureGray,
-    hotColor = ColorScheme.lightPrimary,
-    activeColor = ColorScheme.lightPrimaryHighlight,
-    textAreaColor = ColorScheme.lightGray,
-    activeTextAreaColor = ColorScheme.white,
-    textColor = ColorScheme.black
+    colorScheme = ColorScheme.lightScheme
   )
 
   val darkDefault: Default = Default(
     border = 1,
     activeBorder = 2,
     font = Font.default,
-    inactiveColor = ColorScheme.pureGray,
-    hotColor = ColorScheme.darkPrimary,
-    activeColor = ColorScheme.darkPrimaryHighlight,
-    textAreaColor = ColorScheme.darkGray,
-    activeTextAreaColor = ColorScheme.pureGray,
-    textColor = ColorScheme.white
+    colorScheme = ColorScheme.darkScheme
   )

--- a/core/shared/src/main/scala/eu/joaocosta/interim/skins/WindowSkin.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/interim/skins/WindowSkin.scala
@@ -18,10 +18,7 @@ object WindowSkin extends DefaultSkin:
   final case class Default(
       font: Font,
       border: Int,
-      textColor: Color,
-      panelColor: Color,
-      titleColor: Color,
-      borderColor: Color
+      colorScheme: ColorScheme
   ) extends WindowSkin:
 
     def titleArea(area: Rect): Rect =
@@ -47,25 +44,19 @@ object WindowSkin extends DefaultSkin:
     def renderWindow(area: Rect, title: String)(using uiContext: UiContext): Unit =
       val titleArea = this.titleArea(area)
       val panelArea = this.panelArea(area)
-      rectangle(titleArea, titleColor)
-      text(titleArea, textColor, title, font, HorizontalAlignment.Center, VerticalAlignment.Center)
-      rectangle(panelArea, panelColor)
-      rectangleOutline(area, borderColor, border)
+      rectangle(titleArea, colorScheme.secondary)
+      text(titleArea, colorScheme.text, title, font, HorizontalAlignment.Center, VerticalAlignment.Center)
+      rectangle(panelArea, colorScheme.background)
+      rectangleOutline(area, colorScheme.borderColor, border)
 
   val lightDefault: Default = Default(
     font = Font.default,
     border = 1,
-    textColor = ColorScheme.black,
-    panelColor = ColorScheme.white,
-    titleColor = ColorScheme.lightGray,
-    borderColor = ColorScheme.darkGray
+    colorScheme = ColorScheme.lightScheme
   )
 
   val darkDefault: Default = Default(
     font = Font.default,
     border = 1,
-    textColor = ColorScheme.white,
-    panelColor = ColorScheme.black,
-    titleColor = ColorScheme.darkGray,
-    borderColor = ColorScheme.lightGray
+    colorScheme = ColorScheme.darkScheme
   )


### PR DESCRIPTION
Unifies the skin colors into a single color scheme.

This makes the design a bit more consistent, and it makes it easier to create custom color skins.

It does make the default designs a bit less flexible, but I feel like that's the way to go.