### PR TITLE
Add ComponentWithBody abstraction

### DIFF
--- a/examples/snapshot/1-intro.md
+++ b/examples/snapshot/1-intro.md
@@ -54,7 +54,7 @@ Now, let's write our interface. We are going to need the following components:
 def application(inputState: InputState) =
   import eu.joaocosta.interim.InterIm.*
   ui(inputState, uiContext):
-    if (button(id = "minus", area = Rect(x = 10, y = 10, w = 30, h = 30), label = "-"))
+    button(id = "minus", area = Rect(x = 10, y = 10, w = 30, h = 30), label = "-"):
       counter = counter - 1
     text(
       area = Rect(x = 40, y = 10, w = 30, h = 30),
@@ -64,7 +64,7 @@ def application(inputState: InputState) =
       horizontalAlignment = centerHorizontally,
       verticalAlignment = centerVertically
     )
-    if (button(id = "plus", area = Rect(x = 70, y = 10, w = 30, h = 30), label = "+"))
+    button(id = "plus", area = Rect(x = 70, y = 10, w = 30, h = 30), label = "+"):
       counter = counter + 1
 ```
 
@@ -128,7 +128,7 @@ def immutableApp(inputState: InputState, counter: Int): (List[RenderOp], Int) =
   import eu.joaocosta.interim.InterIm.*
   ui(inputState, uiContext):
     val (decrementCounter, _, incrementCounter) = (
-      button(id = "minus", area = Rect(x = 10, y = 10, w = 30, h = 30), label = "-"),
+      button(id = "minus", area = Rect(x = 10, y = 10, w = 30, h = 30), label = "-")(true).getOrElse(false),
       text(
         area = Rect(x = 40, y = 10, w = 30, h = 30),
         color = Color(0, 0, 0),
@@ -137,7 +137,7 @@ def immutableApp(inputState: InputState, counter: Int): (List[RenderOp], Int) =
         horizontalAlignment = centerHorizontally,
         verticalAlignment = centerVertically
       ),
-      button(id = "plus", area = Rect(x = 70, y = 10, w = 30, h = 30), label = "+")
+      button(id = "plus", area = Rect(x = 70, y = 10, w = 30, h = 30), label = "+")(true).getOrElse(false)
     )
     if (decrementCounter && !incrementCounter) counter - 1
     else if (!decrementCounter && incrementCounter) counter + 1
@@ -154,7 +154,7 @@ def localMutableApp(inputState: InputState, counter: Int): (List[RenderOp], Int)
   import eu.joaocosta.interim.InterIm.*
   var _counter = counter
   ui(inputState, uiContext):
-    if (button(id = "minus", area = Rect(x = 10, y = 10, w = 30, h = 30), label = "-"))
+    button(id = "minus", area = Rect(x = 10, y = 10, w = 30, h = 30), label = "-"):
       _counter = counter - 1
     text(
       area = Rect(x = 40, y = 10, w = 30, h = 30),
@@ -164,7 +164,7 @@ def localMutableApp(inputState: InputState, counter: Int): (List[RenderOp], Int)
       horizontalAlignment = centerHorizontally,
       verticalAlignment = centerVertically
     )
-    if (button(id = "plus", area = Rect(x = 70, y = 10, w = 30, h = 30), label = "+"))
+    button(id = "plus", area = Rect(x = 70, y = 10, w = 30, h = 30), label = "+"):
       _counter = counter + 1
     _counter
 ```

--- a/examples/snapshot/2-layout.md
+++ b/examples/snapshot/2-layout.md
@@ -50,8 +50,8 @@ var counter = 0
 def application(inputState: InputState) =
   import eu.joaocosta.interim.InterIm.*
   ui(inputState, uiContext):
-    columns(area = Rect(x = 10, y = 10, w = 110, h = 30), numColumns = 3, padding = 10) { column =>
-      if (button(id = "minus", area = column(0), label = "-"))
+    columns(area = Rect(x = 10, y = 10, w = 110, h = 30), numColumns = 3, padding = 10): column =>
+      button(id = "minus", area = column(0), label = "-"):
         counter = counter - 1
       text(
         area = column(1),
@@ -61,9 +61,8 @@ def application(inputState: InputState) =
         horizontalAlignment = centerHorizontally,
         verticalAlignment = centerVertically
       )
-      if (button(id = "plus", area = column(2), label = "+"))
+      button(id = "plus", area = column(2), label = "+"):
         counter = counter + 1
-    }
 ```
 
 Now let's run it:
@@ -87,10 +86,10 @@ For example, this is how our application would look like with a dynamic layout:
 def dynamicApp(inputState: InputState) =
   import eu.joaocosta.interim.InterIm.*
   ui(inputState, uiContext):
-    dynamicColumns(area = Rect(x = 10, y = 10, w = 110, h = 30), padding = 10) { column =>
-      if (button(id = "minus", area = column(30), label = "-")) // 30px from the left
+    dynamicColumns(area = Rect(x = 10, y = 10, w = 110, h = 30), padding = 10): column =>
+      button(id = "minus", area = column(30), label = "-"): // 30px from the left
         counter = counter - 1
-      if (button(id = "plus", area = column(-30), label = "+")) // 30px from the right
+      button(id = "plus", area = column(-30), label = "+"): // 30px from the right
         counter = counter + 1
       text(
         area = column(maxSize), // Fill the remaining area
@@ -100,5 +99,4 @@ def dynamicApp(inputState: InputState) =
         horizontalAlignment = centerHorizontally,
         verticalAlignment = centerVertically
       )
-    }
 ```

--- a/examples/snapshot/3-windows.md
+++ b/examples/snapshot/3-windows.md
@@ -42,7 +42,7 @@ def application(inputState: InputState) =
   ui(inputState, uiContext):
     windowArea = window(id = "window", area = windowArea, title = "My Counter", movable = true, closable = false) { area =>
       columns(area = area.shrink(5), numColumns = 3, padding = 10) { column =>
-        if (button(id = "minus", area = column(0), label = "-"))
+        button(id = "minus", area = column(0), label = "-"):
           counter = counter - 1
         text(
           area = column(1),
@@ -52,7 +52,7 @@ def application(inputState: InputState) =
           horizontalAlignment = centerHorizontally,
           verticalAlignment = centerVertically
         )
-        if (button(id = "plus", area = column(2), label = "+"))
+        button(id = "plus", area = column(2), label = "+"):
           counter = counter + 1
       }
     }._2 // We don't care about the value, just the rect

--- a/examples/snapshot/4-refs.md
+++ b/examples/snapshot/4-refs.md
@@ -39,9 +39,9 @@ def application(inputState: InputState) =
   import eu.joaocosta.interim.InterIm.*
   ui(inputState, uiContext):
     // window takes area as a ref, so will mutate the window area variable
-    window(id = "window", area = windowArea, title = "My Counter", movable = true) { area =>
-      columns(area = area.shrink(5), numColumns = 3, padding = 10) { column =>
-        if (button(id = "minus", area = column(0), label = "-"))
+    window(id = "window", area = windowArea, title = "My Counter", movable = true):area =>
+      columns(area = area.shrink(5), numColumns = 3, padding = 10): column =>
+        button(id = "minus", area = column(0), label = "-"):
           counter = counter - 1
         text(
           area = column(1),
@@ -51,10 +51,8 @@ def application(inputState: InputState) =
           horizontalAlignment = centerHorizontally,
           verticalAlignment = centerVertically
         )
-        if (button(id = "plus", area = column(2), label = "+"))
+        button(id = "plus", area = column(2), label = "+"):
           counter = counter + 1
-      }
-    }
 ```
 
 Be aware that, while the code is more concise, coding with out parameters can lead to confusing code where it's hard
@@ -82,10 +80,10 @@ val initialState = AppState()
 def applicationRef(inputState: InputState, appState: AppState) =
   import eu.joaocosta.interim.InterIm.*
   ui(inputState, uiContext):
-    appState.asRefs { (counter, windowArea) =>
-      window(id = "window", area = windowArea, title = "My Counter", movable = true) { area =>
-        columns(area = area.shrink(5), numColumns = 3, padding = 10) { column =>
-          if (button(id = "minus", area = column(0), label = "-"))
+    appState.asRefs: (counter, windowArea) =>
+      window(id = "window", area = windowArea, title = "My Counter", movable = true): area =>
+        columns(area = area.shrink(5), numColumns = 3, padding = 10): column =>
+          button(id = "minus", area = column(0), label = "-"):
             counter := counter.get - 1 // Counter is a Ref, so we need to use :=
           text(
             area = column(1),
@@ -95,11 +93,8 @@ def applicationRef(inputState: InputState, appState: AppState) =
             horizontalAlignment = centerHorizontally,
             verticalAlignment = centerVertically
           )
-          if (button(id = "plus", area = column(2), label = "+"))
+          button(id = "plus", area = column(2), label = "+"):
             counter := counter.get + 1  // Counter is a Ref, so we need to use :=
-        }
-      }
-    }
 ```
 
 Then we can run our app:

--- a/examples/snapshot/5-colorpicker.md
+++ b/examples/snapshot/5-colorpicker.md
@@ -111,11 +111,11 @@ def application(inputState: InputState, appState: AppState) =
             val clipArea = newColumn(maxSize)
             clip(area = clipArea):
               rows(area = clipArea.copy(y = clipArea.y - resultDelta.get, h = resultsHeight), numRows = results.size, padding = 10): rows =>
-                results.zip(rows).foreach { case ((colorName, colorValue), row) =>
-                  if (button(s"$colorName button", row, colorName))
-                    colorPickerArea.modify(_.open)
-                    color := colorValue
-                }
+                results.zip(rows).foreach:
+                  case ((colorName, colorValue), row) =>
+                    button(s"$colorName button", row, colorName):
+                      colorPickerArea.modify(_.open)
+                      color := colorValue
 
       onBottom:
         window(id = "settings", area = PanelState.open(Rect(10, 430, 250, 40)), title = "Settings", movable = false): area =>


### PR DESCRIPTION
Adds a `ComponentWithBody` abstraction that is now used by `button` and `window` (might be later used by layouts as well)

The `button` abstraction was always a bit off, in my opinion. I know that it's common in immediate UIs to have buttons inside if conditions, but I find this problematic, as one needs to be very careful with the use of `else if` clauses (buttons inside an `else if` won't render when the previous buttons are clicked), which in turn makes the code more statement oriented.

While this is an imperative library, I think it's still valuable if everything is an expression, so I hope this simplifies things.