### PR TITLE
Replace `using lib` with `using dep`

### DIFF
--- a/examples/release/example-minart-backend.scala
+++ b/examples/release/example-minart-backend.scala
@@ -1,6 +1,6 @@
 //> using scala "3.3.1"
-//> using lib "eu.joaocosta::minart::0.6.0-M2"
-//> using lib "eu.joaocosta::interim::0.1.6"
+//> using dep "eu.joaocosta::minart::0.6.0-M2"
+//> using dep "eu.joaocosta::interim::0.1.6"
 
 /** This file contains a simple graphical backend written in Minart.
   *

--- a/examples/snapshot/example-minart-backend.scala
+++ b/examples/snapshot/example-minart-backend.scala
@@ -1,6 +1,6 @@
 //> using scala "3.3.1"
-//> using lib "eu.joaocosta::minart::0.6.0-M2"
-//> using lib "eu.joaocosta::interim::0.1.7-SNAPSHOT"
+//> using dep "eu.joaocosta::minart::0.6.0-M2"
+//> using dep "eu.joaocosta::interim::0.1.7-SNAPSHOT"
 
 /** This file contains a simple graphical backend written in Minart.
   *


### PR DESCRIPTION
Scala CLI deprecated `using lib` in favor of `using dep`