### PR TITLE
Simplify component creation

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/interim/Component.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/interim/Component.scala
@@ -3,12 +3,7 @@ package eu.joaocosta.interim
 type Component[+T] = (inputState: InputState.Historical, uiContext: UiContext) ?=> T
 
 trait ComponentWithValue[T]:
-  def allocateArea(using allocator: LayoutAllocator.AreaAllocator): Rect
-
   def render(area: Rect, value: Ref[T]): Component[Unit]
-
-  def render(value: Ref[T])(using allocator: LayoutAllocator.AreaAllocator): Component[Unit] =
-    render(allocateArea, value)
 
   def applyRef(area: Rect, value: Ref[T]): Component[T] =
     render(area, value)
@@ -21,20 +16,27 @@ trait ComponentWithValue[T]:
     case x: T      => applyValue(area, x)
     case x: Ref[T] => applyRef(area, x)
 
+trait DynamicComponentWithValue[T] extends ComponentWithValue[T]:
+  def allocateArea(using allocator: LayoutAllocator.AreaAllocator): Rect
+
+  def render(value: Ref[T])(using allocator: LayoutAllocator.AreaAllocator): Component[Unit] =
+    render(allocateArea, value)
+
   inline def apply(value: T | Ref[T])(using allocator: LayoutAllocator.AreaAllocator): Component[T] =
     apply(allocateArea, value)
 
 trait ComponentWithBody[I, F[_]]:
-  def allocateArea(using allocator: LayoutAllocator.AreaAllocator): Rect
-
   def render[T](area: Rect, body: I => T): Component[F[T]]
-
-  def render[T](body: I => T)(using allocator: LayoutAllocator.AreaAllocator): Component[Unit] =
-    render(allocateArea, body)
 
   def apply[T](area: Rect)(body: I => T): Component[F[T]] = render(area, body)
 
   def apply[T](area: Rect)(body: => T)(using ev: I =:= Unit): Component[F[T]] = render(area, _ => body)
+
+trait DynamicComponentWithBody[I, F[_]] extends ComponentWithBody[I, F]:
+  def allocateArea(using allocator: LayoutAllocator.AreaAllocator): Rect
+
+  def render[T](body: I => T)(using allocator: LayoutAllocator.AreaAllocator): Component[Unit] =
+    render(allocateArea, body)
 
   def apply[T](body: I => T)(using allocator: LayoutAllocator.AreaAllocator): Component[F[T]] =
     render(allocateArea, body)

--- a/core/shared/src/main/scala/eu/joaocosta/interim/Component.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/interim/Component.scala
@@ -1,7 +1,13 @@
 package eu.joaocosta.interim
 
+/** A Component is something that can be shown in the UI.
+  *
+  * It uses the current input state and UI context to draw itself and returns the current value.
+  */
 type Component[+T] = (inputState: InputState.Historical, uiContext: UiContext) ?=> T
 
+/** A Component that returns a value.
+  */
 trait ComponentWithValue[T]:
   def render(area: Rect, value: Ref[T]): Component[Unit]
 
@@ -16,6 +22,10 @@ trait ComponentWithValue[T]:
     case x: T      => applyValue(area, x)
     case x: Ref[T] => applyRef(area, x)
 
+/** A Component that returns a value.
+  *
+  * The area can be computed dynamically based on a layout allocator.
+  */
 trait DynamicComponentWithValue[T] extends ComponentWithValue[T]:
   def allocateArea(using allocator: LayoutAllocator.AreaAllocator): Rect
 
@@ -25,6 +35,8 @@ trait DynamicComponentWithValue[T] extends ComponentWithValue[T]:
   inline def apply(value: T | Ref[T])(using allocator: LayoutAllocator.AreaAllocator): Component[T] =
     apply(allocateArea, value)
 
+/** A Component that computes its value based on a body.
+  */
 trait ComponentWithBody[I, F[_]]:
   def render[T](area: Rect, body: I => T): Component[F[T]]
 
@@ -32,6 +44,10 @@ trait ComponentWithBody[I, F[_]]:
 
   def apply[T](area: Rect)(body: => T)(using ev: I =:= Unit): Component[F[T]] = render(area, _ => body)
 
+/** A Component that computes its value based on a body.
+  *
+  * The area can be computed dynamically based on a layout allocator.
+  */
 trait DynamicComponentWithBody[I, F[_]] extends ComponentWithBody[I, F]:
   def allocateArea(using allocator: LayoutAllocator.AreaAllocator): Rect
 

--- a/core/shared/src/main/scala/eu/joaocosta/interim/Component.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/interim/Component.scala
@@ -1,0 +1,43 @@
+package eu.joaocosta.interim
+
+type Component[+T] = (inputState: InputState.Historical, uiContext: UiContext) ?=> T
+
+trait ComponentWithValue[T]:
+  def allocateArea(using allocator: LayoutAllocator.AreaAllocator): Rect
+
+  def render(area: Rect, value: Ref[T]): Component[Unit]
+
+  def render(value: Ref[T])(using allocator: LayoutAllocator.AreaAllocator): Component[Unit] =
+    render(allocateArea, value)
+
+  def applyRef(area: Rect, value: Ref[T]): Component[T] =
+    render(area, value)
+    value.get
+
+  def applyValue(area: Rect, value: T): Component[T] =
+    apply(area, Ref(value))
+
+  inline def apply(area: Rect, value: T | Ref[T]): Component[T] = inline value match
+    case x: T      => applyValue(area, x)
+    case x: Ref[T] => applyRef(area, x)
+
+  inline def apply(value: T | Ref[T])(using allocator: LayoutAllocator.AreaAllocator): Component[T] =
+    apply(allocateArea, value)
+
+trait ComponentWithBody[I, F[_]]:
+  def allocateArea(using allocator: LayoutAllocator.AreaAllocator): Rect
+
+  def render[T](area: Rect, body: I => T): Component[F[T]]
+
+  def render[T](body: I => T)(using allocator: LayoutAllocator.AreaAllocator): Component[Unit] =
+    render(allocateArea, body)
+
+  def apply[T](area: Rect)(body: I => T): Component[F[T]] = render(area, body)
+
+  def apply[T](area: Rect)(body: => T)(using ev: I =:= Unit): Component[F[T]] = render(area, _ => body)
+
+  def apply[T](body: I => T)(using allocator: LayoutAllocator.AreaAllocator): Component[F[T]] =
+    render(allocateArea, body)
+
+  def apply[T](body: => T)(using allocator: LayoutAllocator.AreaAllocator, ev: I =:= Unit): Component[F[T]] =
+    render(allocateArea, _ => body)

--- a/core/shared/src/main/scala/eu/joaocosta/interim/Panel.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/interim/Panel.scala
@@ -1,0 +1,13 @@
+package eu.joaocosta.interim
+
+trait Panel[I, F[_]]:
+  def render[T](area: Ref[PanelState[Rect]], body: I => T): Component[F[T]]
+
+  def apply[T](area: Ref[PanelState[Rect]])(body: I => T): Component[F[T]] =
+    render(area, body)
+
+  def apply[T](area: PanelState[Rect])(body: I => T): Component[F[T]] =
+    render(Ref(area), body)
+
+  def apply[T](area: Rect)(body: I => T): Component[F[T]] =
+    render(Ref(PanelState.open(area)), body)

--- a/core/shared/src/main/scala/eu/joaocosta/interim/Panel.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/interim/Panel.scala
@@ -1,5 +1,8 @@
 package eu.joaocosta.interim
 
+/*
+ * Panels are a mix of a component and a layout. They perform rendering operations, but also provide a draw area.
+ */
 trait Panel[I, F[_]]:
   def render[T](area: Ref[PanelState[Rect]], body: I => T): Component[F[T]]
 

--- a/core/shared/src/main/scala/eu/joaocosta/interim/TextLayout.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/interim/TextLayout.scala
@@ -89,6 +89,12 @@ object TextLayout:
               )
     layout(textOp.text, 0, Nil).filter(char => (char.area & textOp.area) == char.area)
 
+  /** Computes the area that some text will occupy
+    *
+    * @param boundingArea area where the text can be inserted
+    * @param text string of text
+    * @param font font to use
+    */
   def computeArea(
       boundingArea: Rect,
       text: String,

--- a/core/shared/src/main/scala/eu/joaocosta/interim/api/Components.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/interim/api/Components.scala
@@ -13,48 +13,6 @@ object Components extends Components
 
 trait Components:
 
-  type Component[+T] = (inputState: InputState.Historical, uiContext: UiContext) ?=> T
-
-  trait ComponentWithValue[T]:
-    def allocateArea(using allocator: LayoutAllocator.AreaAllocator): Rect
-
-    def render(area: Rect, value: Ref[T]): Component[Unit]
-
-    def render(value: Ref[T])(using allocator: LayoutAllocator.AreaAllocator): Component[Unit] =
-      render(allocateArea, value)
-
-    def applyRef(area: Rect, value: Ref[T]): Component[T] =
-      render(area, value)
-      value.get
-
-    def applyValue(area: Rect, value: T): Component[T] =
-      apply(area, Ref(value))
-
-    inline def apply(area: Rect, value: T | Ref[T]): Component[T] = inline value match
-      case x: T      => applyValue(area, x)
-      case x: Ref[T] => applyRef(area, x)
-
-    inline def apply(value: T | Ref[T])(using allocator: LayoutAllocator.AreaAllocator): Component[T] =
-      apply(allocateArea, value)
-
-  trait ComponentWithBody[I, F[_]]:
-    def allocateArea(using allocator: LayoutAllocator.AreaAllocator): Rect
-
-    def render[T](area: Rect, body: I => T): Component[F[T]]
-
-    def render[T](body: I => T)(using allocator: LayoutAllocator.AreaAllocator): Component[Unit] =
-      render(allocateArea, body)
-
-    def apply[T](area: Rect)(body: I => T): Component[F[T]] = render(area, body)
-
-    def apply[T](area: Rect)(body: => T)(using ev: I =:= Unit): Component[F[T]] = render(area, _ => body)
-
-    def apply[T](body: I => T)(using allocator: LayoutAllocator.AreaAllocator): Component[F[T]] =
-      render(allocateArea, body)
-
-    def apply[T](body: => T)(using allocator: LayoutAllocator.AreaAllocator, ev: I =:= Unit): Component[F[T]] =
-      render(allocateArea, _ => body)
-
   /** Button component. Returns true if it's being clicked, false otherwise.
     *
     * @param label text label to show on this button

--- a/core/shared/src/main/scala/eu/joaocosta/interim/api/Components.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/interim/api/Components.scala
@@ -21,8 +21,8 @@ trait Components:
       id: ItemId,
       label: String,
       skin: ButtonSkin = ButtonSkin.default()
-  ): ComponentWithBody[Unit, Option] =
-    new ComponentWithBody[Unit, Option]:
+  ): DynamicComponentWithBody[Unit, Option] =
+    new DynamicComponentWithBody[Unit, Option]:
       def allocateArea(using allocator: LayoutAllocator.AreaAllocator): Rect =
         skin.allocateArea(allocator, label)
 
@@ -37,8 +37,8 @@ trait Components:
   final def checkbox(
       id: ItemId,
       skin: CheckboxSkin = CheckboxSkin.default()
-  ): ComponentWithValue[Boolean] =
-    new ComponentWithValue[Boolean]:
+  ): DynamicComponentWithValue[Boolean] =
+    new DynamicComponentWithValue[Boolean]:
       def allocateArea(using allocator: LayoutAllocator.AreaAllocator): Rect =
         skin.allocateArea(allocator)
 
@@ -59,8 +59,8 @@ trait Components:
       buttonValue: T,
       label: String,
       skin: ButtonSkin = ButtonSkin.default()
-  ): ComponentWithValue[T] =
-    new ComponentWithValue[T]:
+  ): DynamicComponentWithValue[T] =
+    new DynamicComponentWithValue[T]:
       def allocateArea(using allocator: LayoutAllocator.AreaAllocator): Rect =
         skin.allocateArea(allocator, label)
 
@@ -85,8 +85,8 @@ trait Components:
       labels: Vector[String],
       defaultLabel: String = "",
       skin: SelectSkin = SelectSkin.default()
-  ): ComponentWithValue[PanelState[Int]] =
-    new ComponentWithValue[PanelState[Int]]:
+  ): DynamicComponentWithValue[PanelState[Int]] =
+    new DynamicComponentWithValue[PanelState[Int]]:
       def allocateArea(using allocator: LayoutAllocator.AreaAllocator): Rect =
         skin.allocateArea(allocator, labels)
 
@@ -115,8 +115,8 @@ trait Components:
       min: Int,
       max: Int,
       skin: SliderSkin = SliderSkin.default()
-  ): ComponentWithValue[Int] =
-    new ComponentWithValue[Int]:
+  ): DynamicComponentWithValue[Int] =
+    new DynamicComponentWithValue[Int]:
       def allocateArea(using allocator: LayoutAllocator.AreaAllocator): Rect =
         skin.allocateArea(allocator)
 
@@ -138,8 +138,8 @@ trait Components:
   final def textInput(
       id: ItemId,
       skin: TextInputSkin = TextInputSkin.default()
-  ): ComponentWithValue[String] =
-    new ComponentWithValue[String]:
+  ): DynamicComponentWithValue[String] =
+    new DynamicComponentWithValue[String]:
       def allocateArea(using allocator: LayoutAllocator.AreaAllocator): Rect =
         skin.allocateArea(allocator)
 
@@ -154,8 +154,8 @@ trait Components:
     * Instead of using this component directly, it can be easier to use [[eu.joaocosta.interim.api.Panels.window]]
     * with movable = true.
     */
-  final def moveHandle(id: ItemId, skin: HandleSkin = HandleSkin.default()): ComponentWithValue[Rect] =
-    new ComponentWithValue[Rect]:
+  final def moveHandle(id: ItemId, skin: HandleSkin = HandleSkin.default()): DynamicComponentWithValue[Rect] =
+    new DynamicComponentWithValue[Rect]:
       def allocateArea(using allocator: LayoutAllocator.AreaAllocator): Rect =
         skin.allocateArea(allocator)
 
@@ -172,8 +172,8 @@ trait Components:
     * Instead of using this component directly, it can be easier to use [[eu.joaocosta.interim.api.Panels.window]]
     * with movable = true.
     */
-  final def resizeHandle(id: ItemId, skin: HandleSkin = HandleSkin.default()): ComponentWithValue[Rect] =
-    new ComponentWithValue[Rect]:
+  final def resizeHandle(id: ItemId, skin: HandleSkin = HandleSkin.default()): DynamicComponentWithValue[Rect] =
+    new DynamicComponentWithValue[Rect]:
       def allocateArea(using allocator: LayoutAllocator.AreaAllocator): Rect =
         skin.allocateArea(allocator)
 
@@ -193,8 +193,8 @@ trait Components:
   final def closeHandle[T](
       id: ItemId,
       skin: HandleSkin = HandleSkin.default()
-  ): ComponentWithValue[PanelState[T]] =
-    new ComponentWithValue[PanelState[T]]:
+  ): DynamicComponentWithValue[PanelState[T]] =
+    new DynamicComponentWithValue[PanelState[T]]:
       def allocateArea(using allocator: LayoutAllocator.AreaAllocator): Rect =
         skin.allocateArea(allocator)
 

--- a/core/shared/src/main/scala/eu/joaocosta/interim/api/Panels.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/interim/api/Panels.scala
@@ -23,15 +23,15 @@ object Panels extends Panels
 trait Panels:
 
   trait Panel[I, F[_]]:
-    def render[T](area: Ref[PanelState[Rect]], body: I => T): Components.Component[F[T]]
+    def render[T](area: Ref[PanelState[Rect]], body: I => T): Component[F[T]]
 
-    def apply[T](area: Ref[PanelState[Rect]])(body: I => T): Components.Component[F[T]] =
+    def apply[T](area: Ref[PanelState[Rect]])(body: I => T): Component[F[T]] =
       render(area, body)
 
-    def apply[T](area: PanelState[Rect])(body: I => T): Components.Component[F[T]] =
+    def apply[T](area: PanelState[Rect])(body: I => T): Component[F[T]] =
       render(Ref(area), body)
 
-    def apply[T](area: Rect)(body: I => T): Components.Component[F[T]] =
+    def apply[T](area: Rect)(body: I => T): Component[F[T]] =
       render(Ref(PanelState.open(area)), body)
 
   /**  Window with a title.
@@ -51,7 +51,7 @@ trait Panels:
       handleSkin: HandleSkin = HandleSkin.default()
   ): Panel[Rect, [T] =>> (Option[T], PanelState[Rect])] =
     new Panel[Rect, [T] =>> (Option[T], PanelState[Rect])]:
-      def render[T](area: Ref[PanelState[Rect]], body: Rect => T): Components.Component[(Option[T], PanelState[Rect])] =
+      def render[T](area: Ref[PanelState[Rect]], body: Rect => T): Component[(Option[T], PanelState[Rect])] =
         if (area.get.isOpen)
           def windowArea = area.get.value
           UiContext.registerItem(id, windowArea, passive = true)

--- a/core/shared/src/main/scala/eu/joaocosta/interim/api/Panels.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/interim/api/Panels.scala
@@ -22,18 +22,6 @@ object Panels extends Panels
 
 trait Panels:
 
-  trait Panel[I, F[_]]:
-    def render[T](area: Ref[PanelState[Rect]], body: I => T): Component[F[T]]
-
-    def apply[T](area: Ref[PanelState[Rect]])(body: I => T): Component[F[T]] =
-      render(area, body)
-
-    def apply[T](area: PanelState[Rect])(body: I => T): Component[F[T]] =
-      render(Ref(area), body)
-
-    def apply[T](area: Rect)(body: I => T): Component[F[T]] =
-      render(Ref(PanelState.open(area)), body)
-
   /**  Window with a title.
     *
     * @param title of this window


### PR DESCRIPTION
Moves some stuff around and creates a distinction between normal components and dynamic components (components that can be created using an layout allocator).

Turns out that in some situations creating dynamic components can either be quite hard or make no sense at all. I think this solution strikes a nice balance: One can start by creating normal components and, if they deem the effort worth it, they can later convert them to dynamic components.